### PR TITLE
Update result CSS: set a cursor pointer on expandable results

### DIFF
--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -8,6 +8,10 @@
   margin-bottom: 20px;
 }
 
+.expand.result {
+  cursor: pointer;
+}
+
 #link_location {
   width: 100%;
 }


### PR DESCRIPTION
The expandable lines can be expanded by clicking on them.
Set a "pointer" cursor (aka "click cursor") for such lines, so user is aware he can click on them.