### PR TITLE
Preperation for release of v3.0.1, fixing installation link.

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,8 +3,8 @@ Release history for Zonemaster component Zonemaster-GUI
 v3.0.1 2019-01-31 (pre-release version)
  
  - Fixes
-   - Corrected flag in installation document that pointed at wrong
-     git tag.
+   - Corrected link in installation document to point at correct
+     git tag (correct release).
 
 
 v3.0.0 2019-01-27 (pre-release version)

--- a/Changes
+++ b/Changes
@@ -4,8 +4,7 @@ v3.0.1 2019-01-31 (pre-release version)
  
  - Status
    - This is a pre-release version not fully tested on all supported
-     OS's and Perl versions. This version will not be available on
-     CPAN.
+     environments.
  - Fixes
    - Corrected link in installation document to point at correct
      git tag (correct release).
@@ -15,8 +14,7 @@ v3.0.0 2019-01-27 (pre-release version)
 
  - Status
    - This is a pre-release version not fully tested on all supported
-     OS's and Perl versions. This version will not be available on
-     CPAN.
+     environments.
  - API change
    - As of version 3.0.0 of Zonemaster-Backend its API has changed and
      this version of Zonemaster-GUI does not work with earlier versions

--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Release history for Zonemaster component Zonemaster-GUI
 
 v3.0.1 2019-01-31 (pre-release version)
  
+ - Status
+   - This is a pre-release version not fully tested on all supported
+     OS's and Perl versions. This version will not be available on
+     CPAN.
  - Fixes
    - Corrected link in installation document to point at correct
      git tag (correct release).

--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 Release history for Zonemaster component Zonemaster-GUI 
 
+v3.0.1 2019-01-31 (pre-release version)
+ 
+ - Fixes
+   - Corrected flag in installation document that pointed at wrong
+     git tag.
+
+
 v3.0.0 2019-01-27 (pre-release version)
 
  - Status

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -35,7 +35,7 @@ sudo yum install httpd
 
 * Install Zonemaster Web GUI
 ```sh
-wget https://github.com/zonemaster/zonemaster-gui/releases/download/v3.0.0/zonemaster_web_gui.zip -O temp.zip
+wget https://github.com/zonemaster/zonemaster-gui/releases/download/v3.0.1/zonemaster_web_gui.zip -O temp.zip
 sudo mkdir -p  /var/www/html/zonemaster-web-gui
 sudo mkdir -p /var/log/zonemaster
 sudo unzip temp.zip -d /var/www/html/zonemaster-web-gui
@@ -72,7 +72,7 @@ sudo systemctl restart apache2
 
 * Install Zonemaster Web GUI
 ```sh
-wget https://github.com/zonemaster/zonemaster-gui/releases/download/v3.0.0/zonemaster_web_gui.zip -O temp.zip
+wget https://github.com/zonemaster/zonemaster-gui/releases/download/v3.0.1/zonemaster_web_gui.zip -O temp.zip
 sudo mkdir -p  /var/www/html/zonemaster-web-gui
 sudo mkdir -p /var/log/zonemaster
 sudo unzip temp.zip -d /var/www/html/zonemaster-web-gui

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zonemaster-gui",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,5 +3,5 @@ export const environment = {
   apiEndpoint: '/api',
   contactAddress: 'contact@zonemaster.net',
   logoUrl: 'assets/images/zonemaster_logo.svg',
-  clientInfo: {version: '3.0.0', id: 'Zonemaster GUI'}
+  clientInfo: {version: '3.0.1', id: 'Zonemaster GUI'}
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,5 +8,5 @@ export const environment = {
   apiEndpoint: 'https://zonemaster.fr/api',
   contactAddress: 'contact@zonemaster.net',
   logoUrl: 'assets/images/zonemaster_logo.svg',
-  clientInfo: {version: '3.0.0', id: 'Zonemaster GUI'}
+  clientInfo: {version: '3.0.1', id: 'Zonemaster GUI'}
 };


### PR DESCRIPTION
When releasing 3.0.0 I mixed the git tags up. I want to bump the version to get it right. Now the installation script points at wrong tag, i.e. wrong version.