### PR TITLE
Expand the collapsed action buttons of the result page.

### DIFF
--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -9,21 +9,21 @@
     </div>
     <div class="col-md-6">
       <div class="pull-right actions_btn" >
-        <a class="btn btn-warning btn-collapsible" (click)="getHistory()">
+        <a class="btn btn-warning" (click)="getHistory()">
           <i class="fa fa-history text-white" aria-hidden="true"></i>
           <span class="text-white">{{'History'|translate}}</span>
         </a>
-        <a class="btn btn-info btn-collapsible" (click)="openModal(exportModal)">
+        <a class="btn btn-info" (click)="openModal(exportModal)">
           <i class="fa fa-cloud-download text-white"></i>
           <span class="text-white">{{'Export'|translate}}</span>
         </a>
-        <a class="btn btn-success btn-collapsible" (click)="openModal(shareLinkModal)">
+        <a class="btn btn-success" (click)="openModal(shareLinkModal)">
           <i class="fa fa-share text-white"></i>
           <span class="text-white">Share</span>
         </a>
 
         <div ngbDropdown class="d-inline-block">
-          <button class="btn btn-secondary btn-collapsible" id="settingsDropdownResult" ngbDropdownToggle>
+          <button class="btn btn-secondary" id="settingsDropdownResult" ngbDropdownToggle>
             <i class="fa fa-wrench text-white"></i>
             <span class="text-white">Settings</span>
           </button>


### PR DESCRIPTION
Fix #33.
Now the action buttons of the result page (history, share, settings, etc.) are expand by default. And so, i removed the collapse animation which is now useless.

Result (expire in 14days) : 
https://screenshots.firefox.com/w28iXn8orpxzM5RG/localhost 