### PR TITLE
remove predelegated test page and merge all form options

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -40,8 +40,7 @@ export function HttpLoaderFactory(http: HttpClient) {
 }
 
 const appRoutes: Routes = [
-  { path: 'domain_check', component: DomainComponent, data: [{preDelegated: false}] },
-  { path: 'pre_delegated_domain_check', component: DomainComponent, data: [{preDelegated: true}] },
+  { path: 'domain_check', component: DomainComponent },
   { path: 'result/:resultID', component: ResultComponent, data: [{directAccess: true}]},
   { path: 'history', component: HistoryComponent},
   { path: 'faq', component: FaqComponent },

--- a/src/app/components/domain/domain.component.html
+++ b/src/app/components/domain/domain.component.html
@@ -15,9 +15,9 @@
               [profiles]="profiles"
               (onDomainCheck)="domainCheck($event)"
               (onfetchFromParent)="fetchFromParent($event)"
+              (onOpenOptions)="openOptions($event)"
     ></app-form>
   </app-header>
-
   <div class="container-fluid">
     <section class="row d-block result" *ngIf="showResult">
       <app-result [resultID]="resultID"></app-result>

--- a/src/app/components/domain/domain.component.html
+++ b/src/app/components/domain/domain.component.html
@@ -1,15 +1,14 @@
   <app-header>
-    <div class="row" *ngIf="preDelegated">
+    <div class="row" *ngIf="is_advanced_options_enabled">
       <div class="text-center m-auto">
         <div class="alert alert-info">
-          {{'Notice! This is an undelegated test'|translate}}
+          {{'Notice! More info on undelegated test'|translate}}
           <br>
           <a routerLink="/faq" fragment="undelegated">{{'What is an undelegated domain test?'|translate}}</a>
         </div>
       </div>
     </div>
     <app-form [is_advanced_options_enabled]="is_advanced_options_enabled"
-              [preDelegated]="preDelegated"
               [domain_check_progression]="domain_check_progression"
               [showProgressBar]="showProgressBar"
               [parentData]="parentData"
@@ -24,7 +23,7 @@
       <app-result [resultID]="resultID"></app-result>
     </section>
 
-    <section class="row about" *ngIf="!showResult && !preDelegated">
+    <section class="row about" *ngIf="!showResult">
       <div class="container">
       <h4>{{'About ZoneMaster'|translate}}</h4>
         <p>        <span class="flag-icon flag-icon-gb"></span>
@@ -34,7 +33,7 @@
       </div>
     </section>
 
-    <section class="row about bg-light pt-2" *ngIf="!showResult && !preDelegated">
+    <section class="row about bg-light pt-2" *ngIf="!showResult">
       <div class="container">
         <h4>{{'About domain name system, DNS'|translate}}</h4>
         <p>
@@ -43,7 +42,7 @@
       </div>
     </section>
 
-    <section class="row" *ngIf="!showResult && !preDelegated">
+    <section class="row" *ngIf="!showResult">
     </section>
 
   </div>

--- a/src/app/components/domain/domain.component.ts
+++ b/src/app/components/domain/domain.component.ts
@@ -34,6 +34,10 @@ export class DomainComponent implements OnInit {
   });
   }
 
+  public openOptions(value) {
+    this.is_advanced_options_enabled = value;
+  }
+
   public domainCheck(data: object) {
     let domainCheckId: string;
 
@@ -54,7 +58,7 @@ export class DomainComponent implements OnInit {
             self.is_advanced_options_enabled = false;
             self.showResult = true;
             self.showProgressBar = false;
-            self.domain_check_progression = 0;
+            self.domain_check_progression = 5;
           }
         });
       }, this.intervalTime);

--- a/src/app/components/domain/domain.component.ts
+++ b/src/app/components/domain/domain.component.ts
@@ -14,15 +14,11 @@ export class DomainComponent implements OnInit {
   public domain_check_progression = 0;
   public showResult = false;
   public showProgressBar = false;
-  public preDelegated;
   public parentData: object;
   public resultID = '';
   public profiles = [];
 
-  constructor(private alertService: AlertService, private dnsCheckService: DnsCheckService, route: ActivatedRoute) {
-    this.preDelegated = route.snapshot.data[0]['preDelegated'];
-    this.is_advanced_options_enabled = this.preDelegated;
-  }
+  constructor(private alertService: AlertService, private dnsCheckService: DnsCheckService) {}
 
   ngOnInit() {
     this.dnsCheckService.profileNames().then( (res: string[]) => this.profiles = res );

--- a/src/app/components/form/form.component.css
+++ b/src/app/components/form/form.component.css
@@ -21,6 +21,9 @@
   width: 100%;
 }
 
+.half-with {
+  width: 50%;
+}
 
 button.launch {
   background-color: #FF5A5F;

--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -51,7 +51,7 @@
     <div class="advanced">
       <label class="d-flex" for="advanced_checkbox">
       <span class="switch">
-          <input type="checkbox" name="advanced_checkbox" id="advanced_checkbox" [(ngModel)]="is_advanced_options_enabled">
+          <input type="checkbox" name="advanced_checkbox" id="advanced_checkbox" (change)="toggleOptions()" [ngModel]="is_advanced_options_enabled">
           <span class="slider round"></span>
         </span>
         <p class="ml-1 pt-1">{{'Options'|translate}}</p>

--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -43,42 +43,45 @@
               <span class="progress-value">{{domain_check_progression}}%</span>
             </ngb-progressbar>
           </p>
-          <form [formGroup]="checkboxForm" class="checkboxForm">
-          <div class="options d-flex" [formArrayName]="'items'" [class.invalid]="!checkboxForm['controls'].selectedItems.valid">
-            <div *ngFor="let protocol of checkboxForm['controls'].items['controls']; let i = index;"
-                 [formGroup]="protocol"
-                 [ngClass]="{'has-error': !checkboxForm['controls'].selectedItems.valid}"
-                 class="form-check form-check-inline">
-
-              <input type="checkbox" class="form-check-input" type="checkbox" formControlName="checked" id="protocol_{{ protocol.controls.key.value }}">
-              <label class="custom-control custom-checkbox form-check-label" attr.for="protocol_{{ protocol.controls.key.value }}">
-                {{ protocol.controls.value.value }}
-              </label>
-            </div>
-          </div>
-          </form>
-          <select [(ngModel)]="form.profile" class="form-control" name="form.profile">
-            <option *ngFor="let profile of profiles" [value]="profile" [selected]="form.profile == profile">{{profile}}</option>
-          </select>
         </form>
-
-        <div class="alert alert-danger" role="alert" [class.invalid]="!checkboxForm.controls.selectedItems.valid" *ngIf="!checkboxForm.controls.selectedItems.valid">
-          {{"Choose at least one protocol" | translate}}
-        </div>
       </div>
     </div>
   </div>
-  <div class="row" *ngIf="preDelegated">
+  <div class="row">
     <div class="advanced">
       <label class="d-flex" for="advanced_checkbox">
       <span class="switch">
           <input type="checkbox" name="advanced_checkbox" id="advanced_checkbox" [(ngModel)]="is_advanced_options_enabled">
           <span class="slider round"></span>
         </span>
-        <p class="ml-1 pt-1">{{'Advanced options'|translate}}</p>
+        <p class="ml-1 pt-1">{{'Options'|translate}}</p>
       </label>
 
       <div *ngIf="is_advanced_options_enabled">
+             <span [formGroup]="checkboxForm" class=" half-with">
+              <span class="options d-flex" [formArrayName]="'items'" [class.invalid]="!checkboxForm['controls'].selectedItems.valid">
+                <span *ngFor="let protocol of checkboxForm['controls'].items['controls']; let i = index;"
+                     [formGroup]="protocol"
+                     [ngClass]="{'has-error': !checkboxForm['controls'].selectedItems.valid}"
+                     class="form-check form-check-inline">
+
+                  <input type="checkbox" class="form-check-input" type="checkbox" formControlName="checked" id="protocol_{{ protocol.controls.key.value }}">
+                  <label class="custom-control custom-checkbox form-check-label" attr.for="protocol_{{ protocol.controls.key.value }}">
+                    {{ protocol.controls.value.value }}
+                  </label>
+                </span>
+              </span>
+            </span>
+          <div class="alert alert-danger" role="alert" [class.invalid]="!checkboxForm.controls.selectedItems.valid" *ngIf="!checkboxForm.controls.selectedItems.valid">
+            {{"Choose at least one protocol" | translate}}
+          </div>
+          <hr>
+          <h4 class="d-inline">Profil</h4>
+            <select [(ngModel)]="form.profile" class="form-control half-with" name="form.profile">
+              <option *ngFor="let profile of profiles" [value]="profile" [selected]="form.profile == profile">{{profile}}</option>
+            </select>
+          <hr>
+
           <h4 class="d-inline">{{'Nameservers'|translate}}</h4>
           <form [formGroup]="NSForm" class="form-inline">
             <div formArrayName="itemRows">
@@ -138,7 +141,6 @@
               </div>
             </div>
           </form>
-
           <br>
           <button class="btn btn-default fetchDataFromParent" (click)="displayDataFromParent()">{{'Fetch data from parent zone'|translate}}</button>
       </div>

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Input, Output } from '@angular/core';
+import {Component, EventEmitter, OnInit, Input, Output, SimpleChanges, OnChanges} from '@angular/core';
 import {
   FormGroup,
   FormControl,
@@ -20,6 +20,7 @@ export class FormComponent implements OnInit {
 
   @Output() onDomainCheck = new EventEmitter<object>();
   @Output() onfetchFromParent = new EventEmitter<string>();
+  @Output() onOpenOptions = new EventEmitter<boolean>();
 
   private NSFormConfig = {
     ns: [''],
@@ -141,5 +142,10 @@ export class FormComponent implements OnInit {
     }
 
     this.onDomainCheck.emit(this.form);
+  }
+
+  public toggleOptions() {
+    this.is_advanced_options_enabled = !this.is_advanced_options_enabled
+    this.onOpenOptions.emit(this.is_advanced_options_enabled);
   }
 }

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -14,7 +14,6 @@ import {AlertService} from '../../services/alert.service';
 })
 export class FormComponent implements OnInit {
   @Input() is_advanced_options_enabled;
-  @Input() preDelegated;
   @Input() domain_check_progression;
   @Input() showProgressBar;
   @Input() profiles;
@@ -122,7 +121,7 @@ export class FormComponent implements OnInit {
   }
 
   public runDomainCheck() {
-    if (this.preDelegated) {
+    if (this.is_advanced_options_enabled) {
       this.form['nameservers'] = (this.NSForm.value.itemRows[0].ip !== '' ? this.NSForm.value.itemRows : []);
       this.form['ds_info'] = (this.digestForm.value.itemRows[0].keytag !== '' ? this.digestForm.value.itemRows : []);
     }

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -17,9 +17,6 @@
             <a class="nav-link" routerLink="/domain_check" routerLinkActive="active">{{'Domain check'|translate}} </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" routerLink="/pre_delegated_domain_check" routerLinkActive="active">{{'Pre-delegated domain'|translate}} </a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" routerLink="/faq" routerLinkActive="active" >{{'FAQ'|translate}} </a>
           </li>
         </ul>

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -56,7 +56,7 @@ export class ResultComponent implements OnInit, OnChanges {
               private alertService: AlertService,
               private translateService: TranslateService,
               private dnsCheckService: DnsCheckService) {
-     this.directAccess = this.activatedRoute.snapshot.data[0]['directAccess'];
+     this.directAccess = (this.activatedRoute.snapshot.data[0] === undefined) ? false : this.activatedRoute.snapshot.data[0]['directAccess'];
   }
 
   ngOnInit() {


### PR DESCRIPTION
Fix #6.

As discussed previously, i removed the pre delegated test. 
The home page now display the "options" button. All the code is exactly the same. The diff between delegated and un delegated test is done by the backend depending of the presence (or not) of the nameserver value in the api request.

Screenshot:
https://screenshots.firefox.com/WcnG0lg41nUqOgEw/localhost 