### PR TITLE
Fix 38 undelegated test broken

### DIFF
--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -27,7 +27,7 @@
                       (click)="runDomainCheck();"
                       class="launch ml-2 btn btn-lg text-white"
                       type="button"
-                      [disabled]="showProgressBar">
+                      [disabled]="showProgressBar || disable_check_button">
                 Check
               </button>
           </div>

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -40,6 +40,7 @@ export class FormComponent implements OnInit {
   public test = {};
   public form = {ipv4: true, ipv6: true, profile: 'default', domain: ''};
   public checkboxForm: FormGroup;
+  public disable_check_button = false;
 
   constructor(private formBuilder: FormBuilder, private alertService: AlertService) {}
 
@@ -79,6 +80,7 @@ export class FormComponent implements OnInit {
 
   @Input()
   set parentData(data: object) {
+    this.disable_check_button = false;
     if (this.NSForm) {
       this.deleteRow('NSForm', 0);
       data['ns_list'].map(ns => {
@@ -104,6 +106,7 @@ export class FormComponent implements OnInit {
   }
 
   private displayDataFromParent() {
+    this.disable_check_button = true;
     this.onfetchFromParent.emit(this.form['domain']);
   }
 
@@ -126,17 +129,17 @@ export class FormComponent implements OnInit {
     this.form['ds_info'] = [];
     this.form['nameservers'] = [];
 
-    if (this.NSForm.value.itemRows[0].name) {
+    if (this.NSForm.value.itemRows.length > 0 && this.NSForm.value.itemRows[0].name) {
       this.form['nameservers'] = (this.NSForm.value.itemRows[0].name !== '' ? this.NSForm.value.itemRows : []);
     }
 
-    if (this.digestForm.value.itemRows[0].keytag !== '' ) {
+    if (this.digestForm.value.itemRows.length > 0 && this.digestForm.value.itemRows[0].keytag !== '' ) {
       if (this.digestForm.value.itemRows[0].digest !== '' ) {
         this.form['ds_info'] = this.digestForm.value.itemRows;
       } else {
         this.alertService.error('Digest required');
       }
-    } else if (this.digestForm.value.itemRows[0].digest !== '') {
+    } else if (this.digestForm.value.itemRows.length > 0 && this.digestForm.value.itemRows[0].digest !== '') {
       this.alertService.error('Keytag required');
     }
 

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -122,9 +122,22 @@ export class FormComponent implements OnInit {
   }
 
   public runDomainCheck() {
-    if (this.is_advanced_options_enabled) {
-      this.form['nameservers'] = (this.NSForm.value.itemRows[0].ip !== '' ? this.NSForm.value.itemRows : []);
-      this.form['ds_info'] = (this.digestForm.value.itemRows[0].keytag !== '' ? this.digestForm.value.itemRows : []);
+
+    this.form['ds_info'] = [];
+    this.form['nameservers'] = [];
+
+    if (this.NSForm.value.itemRows[0].name) {
+      this.form['nameservers'] = (this.NSForm.value.itemRows[0].name !== '' ? this.NSForm.value.itemRows : []);
+    }
+
+    if (this.digestForm.value.itemRows[0].keytag !== '' ) {
+      if (this.digestForm.value.itemRows[0].digest !== '' ) {
+        this.form['ds_info'] = this.digestForm.value.itemRows;
+      } else {
+        this.alertService.error('Digest required');
+      }
+    } else if (this.digestForm.value.itemRows[0].digest !== '') {
+      this.alertService.error('Keytag required');
     }
 
     let atLeastOneChecked = false;

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -70,11 +70,11 @@ export class FormComponent implements OnInit {
     });
 
     this.NSForm = this.formBuilder.group({
-      itemRows: this.formBuilder.array([this.initItemRows(this.NSFormConfig)]) // here
+      itemRows: this.formBuilder.array([this.initItemRows(this.NSFormConfig)])
     });
 
     this.digestForm = this.formBuilder.group({
-      itemRows: this.formBuilder.array([this.initItemRows(this.digestFormConfig)]) // here
+      itemRows: this.formBuilder.array([this.initItemRows(this.digestFormConfig)])
     });
   }
 
@@ -82,20 +82,21 @@ export class FormComponent implements OnInit {
   set parentData(data: object) {
     this.disable_check_button = false;
     if (this.NSForm) {
-      this.deleteRow('NSForm', 0);
+      this.deleteRow('NSForm', -1);
       data['ns_list'].map(ns => {
         this.addNewRow('NSForm', ns);
       });
 
-      this.deleteRow('digestForm', 0);
+      this.deleteRow('digestForm', -1);
       data['ds_list'].map(digest => {
         this.addNewRow('digestForm', digest);
       });
     }
   }
 
-  public addNewRow(form, value= null) {
+  public addNewRow(form, value = null) {
     const control = <FormArray>this[form].controls['itemRows'];
+
     if (value !== null) {
       control.push(this.initItemRows(value));
     } else if (form === 'NSForm') {
@@ -112,7 +113,14 @@ export class FormComponent implements OnInit {
 
   public deleteRow(form, index: number) {
     const control = <FormArray>this[form].controls['itemRows'];
-    control.removeAt(index);
+    if (index === -1) {
+      console.log(control.length);
+      for ( let i = control.length - 1; i >= 0; i--) {
+        control.removeAt(i);
+      }
+    } else {
+      control.removeAt(index);
+    }
   }
 
   public initItemRows(value) {
@@ -129,8 +137,8 @@ export class FormComponent implements OnInit {
     this.form['ds_info'] = [];
     this.form['nameservers'] = [];
 
-    if (this.NSForm.value.itemRows.length > 0 && this.NSForm.value.itemRows[0].name) {
-      this.form['nameservers'] = (this.NSForm.value.itemRows[0].name !== '' ? this.NSForm.value.itemRows : []);
+    if (this.NSForm.value.itemRows.length > 0 && this.NSForm.value.itemRows[0].name !== '') {
+      this.form['nameservers'] = this.NSForm.value.itemRows;
     }
 
     if (this.digestForm.value.itemRows.length > 0 && this.digestForm.value.itemRows[0].keytag !== '' ) {


### PR DESCRIPTION
In order to use custom nameservers, we now accept if the ip is empty but the name is now required.
Same behavior for digest and keytag. 

The user can't run a test (click on the button) during the "fetch data from parent zone" query.

If the user click two or more times on the button "fetch data from parent zone", we only keep the last result. 

Fix #38 