### PR TITLE
Add handler for scroll event to alert message

### DIFF
--- a/src/app/components/alert/alert.component.html
+++ b/src/app/components/alert/alert.component.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container" [ngClass]="{'sticky-top': isShrunk}" >
   <div class="row alert-area">
     <div *ngFor="let alert of alerts" class="{{ cssClass(alert) }} alert-dismissable w-100">
       {{alert.message | translate}}

--- a/src/app/components/alert/alert.component.ts
+++ b/src/app/components/alert/alert.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, NgZone} from '@angular/core';
 
 import { Alert, AlertType } from '../../models/index';
 import { AlertService } from '../../services/alert.service';
@@ -11,8 +11,19 @@ import { AlertService } from '../../services/alert.service';
 export class AlertComponent implements OnInit {
 
   alerts: Alert[] = [];
+  public isShrunk = false;
 
-  constructor(private alertService: AlertService) { }
+  constructor(private alertService: AlertService, zone: NgZone) {
+    window.onscroll = () => {
+      zone.run(() => {
+        if (window.pageYOffset > 1) {
+          this.isShrunk = true;
+        } else {
+          this.isShrunk = false;
+        }
+      });
+    };
+  }
 
   ngOnInit() {
     this.alertService.getAlert().subscribe((alert: Alert) => {


### PR DESCRIPTION
Try to improve the fix for #39 and  #40.
Now the alert message will always appear just after the navbar.

Screenshot:
https://screenshots.firefox.com/ZB6NI3YhPZqX7zuK/localhost