### PR TITLE
Allow remote access to development server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --host 0.0.0.0",
     "build": "node scripts/faq.js && ng build -prod",
     "release": "npm run build && node scripts/create_release.js",
     "test": "ng test",


### PR DESCRIPTION
My development machine is a server without a desktop environment so I need to access the Zonemaster GUI from another machine. By default the development server listens only to 127.0.0.1 which prevents me from accessing it from my actual desktop environment.

This PR makes the development server accessible remotely by updating environment.ts.