### PR TITLE
Stop referring to unsupported OS version

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -97,12 +97,7 @@ to the host's IP or using localhost as ServerName if that is appropriate.
 
 
 * Reload apache
-For Ubuntu 14.04 use the following command:
-```sh
-sudo service apache2 enable
-sudo service apache2 reload
-```
-For Debian and higher versions of Ubuntu use the following command:
+
 ```sh
 sudo systemctl enable apache2
 sudo systemctl reload apache2


### PR DESCRIPTION
Ubuntu 14.04 has reached its end of life and we don't support it anymore.