### PR TITLE
redirect all history call from test to result

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ export function HttpLoaderFactory(http: HttpClient) {
 const appRoutes: Routes = [
   { path: 'domain_check', component: DomainComponent },
   { path: 'result/:resultID', component: ResultComponent, data: [{directAccess: true}]},
+  { path: 'test/:resultID', component: ResultComponent, data: [{directAccess: true}]},
   { path: 'history', component: HistoryComponent},
   { path: 'faq', component: FaqComponent },
   { path: '',


### PR DESCRIPTION
Fix #71 
Allow using /test/:test_id or /result/:test_id to get result of a old test