### PR TITLE
Pre-populated field after "fetch data from parent zone" can be deleted

### DIFF
--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -88,8 +88,7 @@
               <div class="nsForm" *ngFor="let itemrow of NSForm.controls.itemRows.controls; let i=index" [formGroupName]="i">
                 <input formControlName="ns" name='form.ns' class="form-control" placeholder="NS">
                 <input formControlName="ip" name='form.ip' class="form-control" placeholder="IP">
-                <button *ngIf="NSForm.controls.itemRows.controls.length > 1"
-                        (click)="deleteRow('NSForm', i)"
+                <button (click)="deleteRow('NSForm', i)"
                         class="btn btn-danger ">
                   <i class="fa fa-trash" aria-hidden="true"></i>
                 </button>
@@ -127,7 +126,7 @@
                   <option [value]="4">SHA-384</option>
                 </select>
                 <input formControlName="digest" class="form-control" name="digest" placeholder="Digest">
-                <button *ngIf="digestForm.controls.itemRows.controls.length > 1"
+                <button
                         (click)="deleteRow('digestForm',i)"
                         class="btn btn-danger ">
                   <i class="fa fa-trash" aria-hidden="true"></i>

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -109,13 +109,16 @@ export class FormComponent implements OnInit {
   public deleteRow(form, index: number) {
     const control = <FormArray>this[form].controls['itemRows'];
     if (index === -1) {
-      console.log(control.length);
       for ( let i = control.length - 1; i >= 0; i--) {
         control.removeAt(i);
       }
     } else {
       control.removeAt(index);
+      if (control.length === 0) {
+        this.addNewRow(form);
+      }
     }
+
   }
 
   public initItemRows(value) {


### PR DESCRIPTION
Pre-populated field after "fetch data from parent zone" can be deleted

Fix #59  