### PR TITLE
Create empty dir for faqs generation

### DIFF
--- a/src/assets/faqs/.gitkeep
+++ b/src/assets/faqs/.gitkeep
@@ -1,0 +1,1 @@
+# Empty gitkeep file to assure creation of public/js/lib directory by git


### PR DESCRIPTION
Add an empty file to force git to keep the folder "faqs". The folder is needed during the generation of faqs files

Fix #109 
