### PR TITLE
update tsconfig for ivy engine

### DIFF
--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -5,6 +5,11 @@
     "baseUrl": "./",
     "types": []
   },
+  "include": ["src/**/*.ts"],
+  "files": [
+    "main.ts",
+    "polyfills.ts"
+  ],
   "exclude": [
     "test.ts",
     "**/*.spec.ts"


### PR DESCRIPTION
Update tsconfig.app.ts file in order to be compliant with the new angular core engine, ivy.

It removes the WARNING message:
`WARNING in zonemaster-gui/src/environments/environment.prod.ts is part of the TypeScript compilation but it's unused.
Add only entry points to the 'files' or 'include' properties in your tsconfig.`