### PR TITLE
fix(nav): remove github icon when the size is under 1300px to avoid lang issue

### DIFF
--- a/src/app/components/navigation/navigation.component.css
+++ b/src/app/components/navigation/navigation.component.css
@@ -34,6 +34,12 @@ nav {
   }
 }
 
+@media(max-width: 1300px) {
+	 .github {
+		         display: none
+			  }
+		  }
+
 .back-to-top {
   cursor: pointer;
   position: fixed;


### PR DESCRIPTION
fix #114 issue: "Language switch goes to Github instead #114"

Now, we hide the github icon when the screen is less than 1300px which fix the issue.