### PR TITLE
Adding missing unzip for installation on Ubuntu/Debian

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -90,12 +90,6 @@ sudo unzip -d /var/www/html/zonemaster-web-gui zonemaster_web_gui.zip
 rm zonemaster_web_gui.zip
 ```
 
-If `unzip` is not already installed, then install it with the following command 
-and go back and run it again above:
-```sh
-sudo apt-get install unzip
-```
-
 #### Basic apache2 configuration
 
 ```sh

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -72,7 +72,7 @@ sudo systemctl reload httpd
 
 ```sh
 sudo apt-get update && sudo apt-get upgrade -y 
-sudo apt-get install apache2
+sudo apt-get install apache2 unzip
 sudo a2enmod proxy
 sudo a2enmod proxy_http
 sudo a2enmod rewrite


### PR DESCRIPTION
Program `unzip` is required for installation but is not available by default in Ubuntu 18.04.

The change is not strictly needed, but the instructions will be simpler if `unzip` is always included for installation and no extra comment is needed.