### PR TITLE
fix(#138): Change sv to da value in the lang form

### DIFF
--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -39,7 +39,7 @@
             <option lang='sv' value='sv' [selected]="lang === 'sv'">
               Svenska
             </option>
-            <option lang='sv' value='sv' [selected]="lang === 'da'">
+            <option lang='da' value='da' [selected]="lang === 'da'">
               Danish
             </option>
           </select>


### PR DESCRIPTION
Change "SV" to "DA" in the select lang form for small screen (smartphone)
Fix issue #138 