### PR TITLE
Fix fragment in notice box

### DIFF
--- a/docs/FAQ/gui-faq-da.md
+++ b/docs/FAQ/gui-faq-da.md
@@ -12,7 +12,7 @@ Zonemaster
 9. [Zonemaster og privatliv](#q9)
 10. [Hvorfor kan jeg ikke teste mit domænenavn?](#q10)
 11. [Hvilke typer af forespørgsler genererer Zonemaster?](#q11)
-12. [Hvad er en "ikke-delegeret" test?](#undelegated)
+12. [Hvad er en "ikke-delegeret" test?](#q12)
 13. [Hvordan tester jeg en "reverse" zone med Zonemaster?](#q13)
 
 Zonemaster
@@ -119,7 +119,7 @@ er det muligt at få indblik i samtlige forespørgsler, der sendes fra Zonemaste
 Bemærk venligst, at informationerne fra kommandolinjeværktøjet er meget tekniske,
 og kræver en høj viden indenfor DNS.
 
-#### 12. Hvad er en "ikke-delegeret" test? <a name="undelegated"></a>
+#### 12. Hvad er en "ikke-delegeret" test? <a name="q12"></a>
 En "ikke-delegeret" test af et domænenavn betyder, at testen udføres på et
 domænenavn, der måske eller måske ikke er offentliggjort i DNS. Dette kan være
 ganske nyttigt, såfremt man ønsker at udskifte navneservere bag et domænenavn

--- a/docs/FAQ/gui-faq-fr.md
+++ b/docs/FAQ/gui-faq-fr.md
@@ -12,7 +12,7 @@ Zonemaster
 9. [Zonemaster et confidentialité](#q9)
 10. [Comment se fait-il que je ne puisse pas tester mon nom de domaine ?](#q10)
 11. [Quels genres de requêtes Zonemaster génère t-il ?](#q11)
-12. [C'est quoi un test sur un domaine non délégué?](#undelegated)
+12. [C'est quoi un test sur un domaine non délégué?](#q12)
 13. [Comment tester une zone "reverse" avec Zonemaster ?](#q13)
 
 
@@ -171,7 +171,7 @@ de manipuler des données liées au DNS quotidiennement, ce niveau de détail
 pourra être considéré trop technique et réservé à un public averti, les autres 
 pourront se contenter de l'interface "classique".
 
-#### 12. C'est quoi un test sur un nom de domaine non délégué ? <a name="undelegated"></a>
+#### 12. C'est quoi un test sur un nom de domaine non délégué ? <a name="q12"></a>
 
 On va appeler, test sur un nom de domaine non délégué, un test réalisé sur
 une zone non complètement publiée dans le DNS. Cela est particulièrement

--- a/e2e/FR16.e2e-spec.ts
+++ b/e2e/FR16.e2e-spec.ts
@@ -13,7 +13,7 @@ describe('Zonemaster test FR16 - [The advanced view should have a text describin
   it('should have a link to the proper faq answer', () => {
     expect(element(by.css('.alert.alert-info')).isPresent()).toBe(true);
     expect(element(by.css('.alert.alert-info')).element(by.css('a')).getAttribute('routerlink')).toBe('/faq');
-    expect(element(by.css('.alert.alert-info')).element(by.css('a')).getAttribute('fragment')).toBe('undelegated');
+    expect(element(by.css('.alert.alert-info')).element(by.css('a')).getAttribute('fragment')).toBe('q12');
   });
 
   it('should have a description text in multi languages', () => {

--- a/src/app/components/domain/domain.component.html
+++ b/src/app/components/domain/domain.component.html
@@ -4,7 +4,7 @@
         <div class="alert alert-info">
           {{'Notice! More info on undelegated test'|translate}}
           <br>
-          <a routerLink="/faq" fragment="undelegated">{{'What is an undelegated domain test?'|translate}}</a>
+          <a routerLink="/faq" fragment="q12">{{'What is an undelegated domain test?'|translate}}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This updates the fragment value in the notice box to link to the proper FAQ section.

This should fix #147