### PR TITLE
Remove third party stylesheet

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <title>Zonemaster</title>
 
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" rel="stylesheet" />
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
It looks like the Prism stylesheet is not used anywhere. So it seems safe to remove it.
Fixes #151 