### PR TITLE
Centos installation

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -59,7 +59,14 @@ sudo setsebool -P httpd_can_network_connect=1
 sudo install -v /var/www/html/zonemaster-web-gui/zonemaster.conf-example /etc/httpd/conf.d/zonemaster.conf
 ```
 
-Then update the zonemaster.conf file with your own ServerName, ServerAlias, ServerAdmin
+Optionally update the zonemaster.conf.
+E.g. if Zonemaster-Backend RPCAPI runs on another server or on another port (not
+port 5000), update ProxyPass and ProxyPassReserve.
+Or if you want provide your own settings for ServerName, ServerAlias and ServerAdmin.
+
+```sh
+sudoedit /etc/httpd/conf.d/zonemaster.conf
+```
 
 
 #### Start Apache and allow remote access

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -42,17 +42,18 @@ sudo yum install httpd
 
 ```sh
 wget https://github.com/zonemaster/zonemaster-gui/releases/download/v3.2.1/zonemaster_web_gui.zip -O zonemaster_web_gui.zip
-sudo mkdir -p  /var/www/html/zonemaster-web-gui
-sudo mkdir -p /var/log/zonemaster
+sudo install -vd /var/www/html/zonemaster-web-gui
+sudo install -vd /var/log/zonemaster
 sudo unzip -d /var/www/html/zonemaster-web-gui zonemaster_web_gui.zip
-rm zonemaster_web_gui.zip
+rm -f zonemaster_web_gui.zip
 ```
 
 #### Basic httpd configuration
 
 ```sh
-sudo install /var/www/html/zonemaster-web-gui/zonemaster.conf-example /etc/httpd/conf.d/zonemaster.conf
+sudo install -v /var/www/html/zonemaster-web-gui/zonemaster.conf-example /etc/httpd/conf.d/zonemaster.conf
 ```
+
 Then update the zonemaster.conf file with your own ServerName, ServerAlias, ServerAdmin
 
 * Start  httpd if it is newly installed

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -42,7 +42,7 @@ sudo yum install httpd
 #### Install Zonemaster Web GUI
 
 ```sh
-wget https://github.com/zonemaster/zonemaster-gui/releases/download/v3.2.1/zonemaster_web_gui.zip -O zonemaster_web_gui.zip
+curl -O https://github.com/zonemaster/zonemaster-gui/releases/download/v3.2.1/zonemaster_web_gui.zip
 sudo install -vd /var/www/html/zonemaster-web-gui
 sudo install -vd /var/log/zonemaster
 sudo unzip -d /var/www/html/zonemaster-web-gui zonemaster_web_gui.zip

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -53,6 +53,9 @@ rm -f zonemaster_web_gui.zip
 #### Configure Apache site
 
 ```sh
+sudo chcon -R -t httpd_sys_content_t /var/www/html/zonemaster-web-gui/dist
+sudo chcon -R -t httpd_sys_rw_content_t /var/log/zonemaster
+sudo setsebool -P httpd_can_network_connect=1
 sudo install -v /var/www/html/zonemaster-web-gui/zonemaster.conf-example /etc/httpd/conf.d/zonemaster.conf
 ```
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -31,12 +31,13 @@ This instruction covers the following operating systems:
 
 ### 1. CentOS
 
-* Install Httpd (Apache), if it is not installed:
+#### Install Apache
 
 ```sh
 sudo yum update
 sudo yum install httpd
 ```
+
 
 #### Install Zonemaster Web GUI
 
@@ -48,7 +49,8 @@ sudo unzip -d /var/www/html/zonemaster-web-gui zonemaster_web_gui.zip
 rm -f zonemaster_web_gui.zip
 ```
 
-#### Basic httpd configuration
+
+#### Configure Apache site
 
 ```sh
 sudo install -v /var/www/html/zonemaster-web-gui/zonemaster.conf-example /etc/httpd/conf.d/zonemaster.conf
@@ -56,17 +58,14 @@ sudo install -v /var/www/html/zonemaster-web-gui/zonemaster.conf-example /etc/ht
 
 Then update the zonemaster.conf file with your own ServerName, ServerAlias, ServerAdmin
 
-* Start  httpd if it is newly installed
+
+#### Start Apache
+
 ```sh
 sudo systemctl enable httpd
 sudo systemctl start httpd
 ```
 
-* Else, Reload httpd
-```sh
-sudo systemctl enable httpd
-sudo systemctl reload httpd
-```
 
 ### 2. Debian
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -59,11 +59,13 @@ sudo install -v /var/www/html/zonemaster-web-gui/zonemaster.conf-example /etc/ht
 Then update the zonemaster.conf file with your own ServerName, ServerAlias, ServerAdmin
 
 
-#### Start Apache
+#### Start Apache and allow remote access
 
 ```sh
 sudo systemctl enable httpd
 sudo systemctl start httpd
+sudo firewall-cmd --add-service http --permanent
+sudo firewall-cmd --reload
 ```
 
 


### PR DESCRIPTION
The instruction is updated to:
* Relieve users of from having to figure out that they need to disable/configure SELinux and how to do it.
* Enable remote access to the Web GUI by opening up the firewall.
* Clarify that editing zonemaster.conf is optional, and provide a cut-and-pasteable command.
* Give more feedback and require less interaction.
* Fix the headings.