### PR TITLE
Updates TranslationGuide

### DIFF
--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -30,9 +30,9 @@ submit the new or updated file as a pull request to Github (see
 [translators guide for Engine]). Contact the Zonemaster Group if
 that does not work.
 
-The changes in or addition of *LANG.json* and *gui-faq-LANG.md* must
-be completed by a translator. The other changes are only done when
-a language is added and can be completed by the Zonemaster Group.
+The translator must always create or update the *LANG.json* and 
+the *gui-faq-LANG.md*. The other changes are only done when
+a language is added and will be completed by the Zonemaster Group.
 
 
 ## LANG.json
@@ -54,7 +54,7 @@ translate the file using English as the model.
 
 ## gui-faq-LANG.md
 
-The FAQ documents holds questions and answers on Zonemaster, and there
+The FAQ document holds questions and answers on Zonemaster, and there
 is one document per language, e.g. `gui-faq-en.md`.
 
 The files are located in the [docs/FAQ] folder, one file for each supported
@@ -115,7 +115,7 @@ The new language must be added to the following files:
 In `package.json` locate
 
 ```
-    "i18n:extract": "ngx-translate-extract --input ./src --output ./src/assets/i18n/{en,da,fr,sv}.json --key-as-default-value --clean --sort --format json"
+    "i18n:extract": "ngx-translate-extract --input ./src --output ./src/assets/i18n/{da,en,fr,sv}.json --key-as-default-value --clean --sort --format json"
 ```
 and add the two-letter language code of the new language. Preserve
 the alphabetical order of the language codes.

--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -1,49 +1,175 @@
-#To translate the Zonemaster frontend interface 2 files must be added.
+# Translation Guide
 
-* The JSON structure holding all the messages of the Web Interface
-* The file holding the FAQ
+This guide gives instructions for how to add a new language to
+Zonemaster-GUI. The language is assumed to exist in or to be added
+to Zonemaster-Engine and Zonemaster-Backend.
 
-1. Adding the JSON structure holding all the messages of the Web Interface
+When updating a language in use, this document could also be used as
+a checklist for where the changes are done.
 
-The file is located in the following folder:
-```
-ZONEMASTER_DISTRIBUTION/zonemaster-gui/src/assets/i18n
-```
-This folder contains the language files.
+You should usually read this document from develop branch to make
+sure you have the latest version.
 
-Each language file contains a hash structure with English/Default messages as keys and the translated messges as values.
-The file should be named with the [official language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and must have .json extension.
+## Language code
 
-2. Adding the file holding the FAQ
-The file is located in the following folder:
-```
-ZONEMASTER_DISTRIBUTION/zonemaster/docs/FAQ
-```
-The filename must be of the format: qui-faq-LANGUAGE_CODE.md
-Where LANGUAGE_CODE is the standard 2 letter language code from: [official language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+Zonemaster uses [ISO 639-1] two-letter language codes, normally in
+lower case, but in GUI sometimes with first letter in upper case
+to make the display nicer. GUI is currently available in the
+following languages with the attached language code:
 
-3. Ading the language link to the web interface
-The file that needs to be modified is locaded in the following folder:
+* `da` for Danish language
+* `en` for English language
+* `fr` for French language
+* `sv` for Swedish language
+
+
+## Submitting changes
+
+Below are instructions for how to add or modify files. Preferably,
+submit the new or updated file as a pull request to Github (see
+[translators guide for Engine]). Contact the Zonemaster Group if
+that does not work.
+
+The changes in or addition of *LANG.json* and *gui-faq-LANG.md* must
+be completed by a translator. The other changes are only done when
+a language is added and can be completed by the Zonemaster Group.
+
+
+## LANG.json
+
+The JSON structure LANG.json holds all the messages for GUI in respective
+language, where "LANG" is the language code, e.g. `en.json`.
+
+The files are located in the [src/assets/i18n] folder, one file for each
+supported language.
+
+Each language file contains a hash structure with the English message
+(default messages) as the key and the translated messages as the value. In
+a few cases, when the value is long, the key is a KEY_STRING.
+
+When creating a new language file, make a copy of `en.json` with the new
+language code instead of `en`. The code must be in lower case. Then
+translate the file using English as the model.
+
+
+## gui-faq-LANG.md
+
+The FAQ documents holds questions and answers on Zonemaster, and there
+is one document per language, e.g. `gui-faq-en.md`.
+
+The files are located in the [docs/FAQ] folder, one file for each supported
+language.
+
+When creating a new FAQ file, make a copy of `gui-faq-en.md` with the new
+language code instead of `en`. The code must be in lower case. Then
+translate the file using English as the model.
+
+It is important to preserve the structure of the file. There must be a
+table of contents linking to the question plus answer below. The anchor
+names must be "q1" etc and nothing else. There are links in the code
+that assume this model.
+
 ```
-ZONEMASTER_DISTRIBUTION/zonemaster-gui/src/app/components/navigation.component.html
+1. [What is Zonemaster?](#q1)
+
+#### 1. What is Zonemaster? <a name="q1"></a>
 ```
+
+## Add the language to HTML code
+
+The language must be linked from the GUI. The new language must be added
+to [src/app/components/navigation/navigation.component.html]:
 
 In `navigation.component.html` :
 
- - Locate the div `<div class="lang">`
- - Add your language using the language tag: `<a lang='xx' (click)="setLanguage('xx')">XX</a> |`
-with xx, the language code in lower case and XX, the displayed language code.
- - Finally, for small (mobile) screen, add in the next select element:
- ``` 
+  * Locate the div `<div class="lang">`
+  * Add the language where `xx` is the language code in lower case, e.g.
+    `en` and `Yy` is the same language code with first letter in upper
+    case, e.g. `En`:
+
+```
+<a lang='xx' (click)="setLanguage('xx')">Yy</a> |
+```
+  * Add the language a second time where `xx` is the language code in
+    lower case, e.g. `sv`, and `Yyyyy` is the name of the same language
+    in that language, e.g. `Svenska`:
+
+```
  <option lang='xx' value='xx' [selected]="lang === 'xx'">
-  Xxxxx
+  Yyyyy
  </option>
  ```
- with Xxxxx, the full language name (En => English).
- 
- 
-4. Optionally, to change the default language update the following file: 
+
+Preserve the alphabetical order of the language codes.
+
+## Add the language in Type Script code
+
+The new language must be added to the following files:
+
+* [package.json]
+* [src/app/app.module.ts]
+* [src/app/components/navigation/navigation.component.ts]
+
+### package.json
+
+In `package.json` locate
+
 ```
-ZONEMASTER_DISTRIBUTION/zonemaster-gui/src/app/components/navigation.component.ts
+    "i18n:extract": "ngx-translate-extract --input ./src --output ./src/assets/i18n/{en,da,fr,sv}.json --key-as-default-value --clean --sort --format json"
 ```
-and replace `public lang = 'en'` by `public lang = 'xx';` with xx the language code of your language.
+and add the two-letter language code of the new language. Preserve
+the alphabetical order of the language codes.
+
+### app.module.ts
+
+In `app.module.ts` locate
+
+```
+import 'moment/locale/fr';
+import 'moment/locale/sv';
+```
+and add a new line with code of the new language instead of `xx`
+```
+import 'moment/locale/xx';
+```
+Preserve the alphabetical order of the language codes.
+
+### navigation.component.ts
+
+In `navigation.component.ts` locate
+
+```
+  private isValidLanguage(lang: string) {
+    const validLanguages = [ 'da', 'en', 'fr', 'sv' ];
+```
+and add the two-letter language code of the new language. Preserve
+the alphabetical order of the language codes.
+
+
+## Change default language
+
+Optionally, to change the default language update
+[src/app/components/navigation/navigation.component.ts].
+
+In `navigation.component.ts` update the following code
+```
+  public lang = 'en';
+  private lang_default = 'en';
+```
+by setting another language code instead of `en` in both cases (they
+should be the same). Such a change **must not** be submitted to the
+Zonemaster repository. Instead it should be done in the local
+installation. Also, it will be overwritten next time Zonemaster GUI
+is updated.
+
+
+[ISO 639-1]:                                               https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+[docs/FAQ]:                                                FAQ
+[package.json]:                                            ../package.json
+[src/app/app.module.ts]:                                   ../src/app/app.module.ts
+[src/app/components/navigation/navigation.component.html]: ../src/app/components/navigation/navigation.component.html
+[src/app/components/navigation/navigation.component.ts]:   ../src/app/components/navigation/navigation.component.ts
+[src/assets/i18n]:                                         ../src/assets/i18n
+[translators guide for Engine]:                            https://github.com/zonemaster/zonemaster-engine/blob/develop/docs/Translation-translators.md
+
+


### PR DESCRIPTION
This PR contains the same changes to TranslationGuide.md as #165 with the addition of documenting the new places where language code is set that #169 introduced. In addition comment to retain alphabetical order is added.

#165 will be closed when the remaining of it has been moved to a new PR.

This is an update of the document for upcoming translation work.