### PR TITLE
Corrects git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,10 +46,12 @@ Thumbs.db
 
 *.zip
 
-gui-faq-*
-src/assets/faqs/gui-faq-*
+# Generated FAQ files
+src/assets/faqs/gui-faq-*.html
 
 *.log
 tests_output/
 .e2e-chrome-profile/
 
+# Emacs backup files
+*~


### PR DESCRIPTION
With the current .gitignore, the `docs/FAQ/gui-faq-*` files are erroneously ignored. They must not be ignored.

* Makes the FAQ md files being not ignored.
* Specifies the path to generated FAQ html files to be ignored.
* Adds emacs backup files to be ignored.