### PR TITLE
Consistent date format

### DIFF
--- a/src/app/components/history/history.component.html
+++ b/src/app/components/history/history.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div *ngIf="history.length > 0;else noHistory" class="list-group w-100">
       <div *ngFor="let item of historyItems" class="list-group-item list-group-item-action list-group-item-{{item.color}}">
-        <a routerLink="/result/{{item.id}}"> {{ item.creation_time | date:'yyyy-MM-dd HH:mm' }} UTC </a>
+        <a routerLink="/result/{{item.id}}"> {{ item.creation_time | amFromUtc | date:'yyyy-MM-dd HH:mm zzzz' }}</a>
 
       </div>
     </div>

--- a/src/app/components/history/history.component.html
+++ b/src/app/components/history/history.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div *ngIf="history.length > 0;else noHistory" class="list-group w-100">
       <div *ngFor="let item of historyItems" class="list-group-item list-group-item-action list-group-item-{{item.color}}">
-        <a routerLink="/result/{{item.id}}"> {{ item.creation_time | date:'M/d/yy, h:mm a z' }} </a>
+        <a routerLink="/result/{{item.id}}"> {{ item.creation_time | date:'yyyy-MM-dd HH:mm' }} UTC </a>
 
       </div>
     </div>

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -5,7 +5,7 @@
   <div class="row">
     <div class="col-md-6">
       <h2>{{'Test #'|translate}}{{ test.id }}<small> - {{form.domain}}</small></h2>
-      <i>{{ test.creation_time | date:'yyyy-MM-dd HH:mm' }} UTC</i>
+      <i>{{ test.creation_time | amFromUtc | date:'yyyy-MM-dd HH:mm zzzz' }}</i>
     </div>
     <div class="col-md-6">
       <div class="pull-right actions_btn" >

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -5,7 +5,7 @@
   <div class="row">
     <div class="col-md-6">
       <h2>{{'Test #'|translate}}{{ test.id }}<small> - {{form.domain}}</small></h2>
-      <i>{{ test.creation_time  | amFromUtc | amLocal | amLocale: language | amDateFormat:'LLL'}}</i>
+      <i>{{ test.creation_time | date:'yyyy-MM-dd HH:mm' }} UTC</i>
     </div>
     <div class="col-md-6">
       <div class="pull-right actions_btn" >


### PR DESCRIPTION
This updates the date format to `YYYY-mm-dd HH:MM UTC` everywhere (in the result page and the history).
This requires that the Backend sends the `creation_time` in UTC (which is not the case with SQLite yet, see https://github.com/zonemaster/zonemaster-backend/pull/732)

Angular documentation on date formats : https://angular.io/api/common/DatePipe

Addresses #189 