### PR TITLE
Tweak to put links just below the navbar

### DIFF
--- a/docs/FAQ/gui-faq-da.md
+++ b/docs/FAQ/gui-faq-da.md
@@ -17,7 +17,8 @@ Zonemaster
 
 Zonemaster
 ----------
-#### 1. Hvad er Zonemaster? <a name="q1"></a>
+<a name="q1"></a>
+#### 1. Hvad er Zonemaster?
 Zonemaster er et program, der er designet til at hjælpe med at tjekke, måle
 og forhåbentlig også forstå DNS (Domain Name System).
 
@@ -35,11 +36,13 @@ DNS fra roden (.) til TLD (Top Level Domæne, eksempelvis .dk) og navneservere, 
 informationer om det specifikke domænenavn ("zonemaster.dk"). De forskellige sundhedstjek
 foretaget af Zonemaster er dokumenteret i [Test Requirements document](https://github.com/zonemaster/zonemaster/blob/master/docs/requirements/TestRequirements.md)
 
-#### 2. Hvem står bag Zonemaster? <a name="q2"></a>
+<a name="q2"></a>
+#### 2. Hvem står bag Zonemaster?
 Zonemaster er et fælles projekt mellem IIS (administrator af .se og .nu) og Afnic
 (administrator af .fr samt oversøiske territorier som tilhører Frankrig).
 
-#### 3. Hvordan kan Zonemaster hjælpe mig? <a name="q3"></a>
+<a name="q3"></a>
+#### 3. Hvordan kan Zonemaster hjælpe mig?
 Zonemaster er orienteret mod to forskellige typer mennesker:
 
   - Mennesker som ved hvordan DNS fungerer og
@@ -48,12 +51,14 @@ Zonemaster er orienteret mod to forskellige typer mennesker:
 Den anden kategori kan med fordel kontakte den første kategori med spørgsmål til
 resultater af testen (konfigurationen).
 
-#### 4. Zonemaster rapporterer advarsler/fejl på mit domænenavn, hvad betyder det? <a name="q4"></a>
+<a name="q4"></a>
+#### 4. Zonemaster rapporterer advarsler/fejl på mit domænenavn, hvad betyder det?
 Det kommer naturligvis an på hvilke advarsler/fejl, der rapporteres. I de fleste
 tilfælde kan du trykke på den aktuelle "advarsler/fejl"-besked og få detaljerede
 informationer om problemet.
 
-#### 5. Hvordan kan Zonemaster afgøre hvad der er rigtigt og forkert? <a name="q5"></a>
+<a name="q5"></a>
+#### 5. Hvordan kan Zonemaster afgøre hvad der er rigtigt og forkert?
 Der er ikke nogen endegyldig dom over et domænenavns sundhed. Folkene bag Zonemaster påstår ikke,
 at værktøjet er korrekt i ethvert aspekt. Sommetider er meninger forskellige, især mellem lande,
 men nogle gange også lokalt. Vi har gjort vores bedste for at skabe en standard (politik)
@@ -66,14 +71,17 @@ til en fejl på et senere tidspunkt. Hvis du mener, at Vi har lavet en fejl, så
 sende os en e-mail på adressen zonemaster-devel@lists.iis.se med et link til din test
 og en forklaring på, hvorfor du mener, at resultatet viser noget, som du anser forkert.
 
-#### 6. Understøtter Zonemaster IPv6? <a name="q6"></a>
+<a name="q6"></a>
+#### 6. Understøtter Zonemaster IPv6?
 Ja, den gør. Alle tests over IPv4 bliver også udført over IPv6, hvis Zonemaster
 er konfigureret til at gøre det.
 
-#### 7. Understøtter Zonemaster DNSSEC? <a name="q7"></a>
+<a name="q7"></a>
+#### 7. Understøtter Zonemaster DNSSEC?
 Ja. Hvis DNSSEC er tilgængeligt på et domænenavn, vil det automtisk blive testet.
 
-#### 8. Hvad gør Zonemaster forkellig fra andre tilsvarende test-værktøjer? <a name="q8"></a>
+<a name="q8"></a>
+#### 8. Hvad gør Zonemaster forkellig fra andre tilsvarende test-værktøjer?
 Først og fremmest gemmer Zonemaster al historik fra tidligere tests, hvilket betyder, at du kan
 gå tilbage til en tidligere test og sammenligne den med den test som du har udført for
 et øjeblik siden.
@@ -87,12 +95,14 @@ Sidst, men ikke mindst, så er Zonemaster open source og opbygget af flere modul
 betyder, at du kan bruge de dele, der er relevante i dit system. Det er sjældent, at du
 ønsker den fulde installation, såfremt du eksempelvis blot ønsker at teste redelegeringer.
 
-#### 9. Zonemaster og privatliv <a name="q9"></a>
+<a name="q9"></a>
+#### 9. Zonemaster og privatliv
 Da Zonemaster er tilgængelig for allei, er det muligt for hvem som helst at tjekke dit
 domænenavn samt læse tidligere testresultater. Men det er ikke muligt at se, hvem der
 har udført de enkelte tests, da det udelukkende er tidspunktet for testen, der logges.
 
-#### 10. Hvorfor kan jeg ikke teste mit domænenavn? <a name="q10"></a>
+<a name="q10"></a>
+#### 10. Hvorfor kan jeg ikke teste mit domænenavn?
 Bortset fra den situation, hvor domænenavnet ikke eksisterer, findes der 2 andre muligheder:
 
   - For at beskytte motoren mod flere samtidige tests (den samme IP-adresse tester
@@ -110,7 +120,8 @@ ikke blive testet. Dette sker heldigvis sjældent, og er indtil videre kun obser
 tilfælde, hvor alle domænenavnets navneservere er registreret under domænenavnet, og disse
 navneservere er ustabile.
 
-#### 11. Hvilke typer af forespørgsler genererer Zonemaster? <a name="q11"></a>
+<a name="q11"></a>
+#### 11. Hvilke typer af forespørgsler genererer Zonemaster?
 Dette spørgsmål er meget svært at svare på, da Zonemaster genererer forskellige
 forespørgsler afhængigt af de svar som den får fra navneserverne. Den eneste måde
 at få et fuldt overblik over forespørgsler, er at afvikle kommandolinjeværktøjet
@@ -119,7 +130,8 @@ er det muligt at få indblik i samtlige forespørgsler, der sendes fra Zonemaste
 Bemærk venligst, at informationerne fra kommandolinjeværktøjet er meget tekniske,
 og kræver en høj viden indenfor DNS.
 
-#### 12. Hvad er en "ikke-delegeret" test? <a name="q12"></a>
+<a name="q12"></a>
+#### 12. Hvad er en "ikke-delegeret" test?
 En "ikke-delegeret" test af et domænenavn betyder, at testen udføres på et
 domænenavn, der måske eller måske ikke er offentliggjort i DNS. Dette kan være
 ganske nyttigt, såfremt man ønsker at udskifte navneservere bag et domænenavn
@@ -128,7 +140,8 @@ inden redelegering. Såfremt Zonemasters testresultat er "grønt", er der stor
 sandsynlighed for, at de nye navneservere er konfigureret korrekt, og en
 redelegering vil kunne udføres med succes.
 
-#### 13. Hvordan tester jeg en "reverse" zone med Zonemaster? <a name="q13"></a>
+<a name="q13"></a>
+#### 13. Hvordan tester jeg en "reverse" zone med Zonemaster?
 For at teste en "reverse" zone med Zonemaster, skal man kende netværksadressen
 (IPv4 eller IPv6) samt netmasken bag netværket.
 

--- a/docs/FAQ/gui-faq-en.md
+++ b/docs/FAQ/gui-faq-en.md
@@ -17,7 +17,9 @@ Zonemaster
 
 Zonemaster
 ----------
-#### 1. What is Zonemaster? <a name="q1"></a>
+
+<a name="q1"></a>
+#### 1. What is Zonemaster?
 Zonemaster is a program that was designed to help people check, measure and
 hopefully also understand how DNS (Domain Name System) works.
 
@@ -36,7 +38,8 @@ the information about the specific domain (zonemaster.net). The different sanity
 conducted by the Zonemaster tool is documented in the [Test Requirements
 document](https://github.com/zonemaster/zonemaster/blob/master/docs/requirements/TestRequirements.md).
 
-#### 2. Who is behind Zonemaster? <a name="q2"></a>
+<a name="q2"></a>
+#### 2. Who is behind Zonemaster?
 Zonemaster is a joint project between [Afnic](https://www.afnic.fr/en/)
 (registry operator of .fr TLD and several other
 TLDs, e.g. .re, .pm, .tf, .wf, .yt and .paris) and
@@ -44,7 +47,8 @@ TLDs, e.g. .re, .pm, .tf, .wf, .yt and .paris) and
 (registry
 operator of .se and .nu TLDs).
 
-#### 3. How can Zonemaster help me? <a name="q3"></a>
+<a name="q3"></a>
+#### 3. How can Zonemaster help me?
 The Zonemaster tool is oriented towards two user categories:
 
   - Users who are knowledgable about the DNS protocol.
@@ -55,10 +59,12 @@ Users of the second category should contact their DNS operator
 as soon as they get the results other than "green" for any
 test of their domain name.
 
-#### 4. Zonemaster returns "Error" or "Warning" for my domain. What does it mean? <a name="q4"></a>
+<a name="q4"></a>
+#### 4. Zonemaster returns "Error" or "Warning" for my domain. What does it mean?
 It depends on which test failed for your domain.
 
-#### 5. How can Zonemaster judge what is right and wrong? <a name="q5"></a>
+<a name="q5"></a>
+#### 5. How can Zonemaster judge what is right and wrong?
 There is no final judgement of the health of a domain that can be bestowed by
 anyone. The people behind Zonemaster do not claim that the tool is correct in
 every aspect. Sometimes opinions differ. We have done our very best to create a
@@ -74,15 +80,18 @@ we have made a mistake in our judgement please do not hesitate to drop us an ema
 at zonemaster-devel@lists.iis.se with a link to your test and an explanation why you think it
 shows something that you consider incorrect.
 
-#### 6. Does Zonemaster handle IPv6? <a name="q6"></a>
+<a name="q6"></a>
+#### 6. Does Zonemaster handle IPv6?
 Yes, it does. All tests run over IPv4 will also be run over IPv6 if Zonemaster
 is configured to do so.
 
-#### 7. Does Zonemaster handle DNSSEC? <a name="q7"></a>
+<a name="q7"></a>
+#### 7. Does Zonemaster handle DNSSEC?
 Yes, if DNSSEC is available for a domain that is tested by Zonemaster, it will be
 checked automatically.
 
-#### 8. What makes Zonemaster differ from other DNS zone validating software? <a name="q8"></a>
+<a name="q8"></a>
+#### 8. What makes Zonemaster differ from other DNS zone validating software?
 Firstly, Zonemaster saves all history from earlier tests based on the tested
 domain, which means you can go back to a test you did a week ago and compare it
 to the test you ran a moment ago.
@@ -99,12 +108,14 @@ which, basically, means you can use parts of it in your systems, if you would wa
 to. It is quite rare that you'd want a complete program just to check for example
 redelegations.
 
-#### 9. Zonemaster and privacy <a name="q9"></a>
+<a name="q9"></a>
+#### 9. Zonemaster and privacy
 Since Zonemaster is open to everyone it is possible for anyone to check your
 domain and also see previous tests, however there is no way to tell
 who has run a specific test since nothing is logged except the time of the test.
 
-#### 10. How come I cannot test my domain? <a name="q10"></a>
+<a name="q10"></a>
+#### 10. How come I cannot test my domain?
 If we disregard the situation where the domain does not exist, as in when you input a
 non-existing domain to Zonemaster, there are 2 other possibilites:
   - To protect the engine from multiple identical inputs, that is the same IP
@@ -117,7 +128,8 @@ non-existing domain to Zonemaster, there are 2 other possibilites:
     report a failure if you try to test a host name instead of a domain matching a
     DNS zone.
 
-#### 11. What kind of queries does Zonemaster generate? <a name="q11"></a>
+<a name="q11"></a>
+#### 11. What kind of queries does Zonemaster generate?
 Zonemaster send multiple DNS queries to the name servers hosting the domain name and
 also to the name servers hosting the parent zone of the domain name.
 
@@ -128,7 +140,8 @@ complete package and install it) and select full output.
 The output from the CLI tool is quite heavily technical
 so unless you are into bits and bytes you might want to skip this step.
 
-#### 12. What is an undelegated domain test? <a name="q12"></a>
+<a name="q12"></a>
+#### 12. What is an undelegated domain test?
 An undelegated domain test is a test performed on a domain that may, or may not,
 be fully published in the DNS. This can be quite useful if one is going to move
 one's domain from one registrar to another,
@@ -140,7 +153,8 @@ When the results of the test are colour coded in green one can be fairly certain
 that the domain's new location is working well. However there
 might still be other problems in the zone data itself that this test is unaware of.
 
-#### 13. How can I test a "reverse" zone with Zonemaster? <a name="q13"></a>
+<a name="q13"></a>
+#### 13. How can I test a "reverse" zone with Zonemaster?
 To check a reverse zone with Zonemaster one need to first know what the
 reverse zone is. If you want to check the reverse zone, you have to enter
 it in the format that it has in DNS, e.g.:

--- a/docs/FAQ/gui-faq-fr.md
+++ b/docs/FAQ/gui-faq-fr.md
@@ -17,7 +17,8 @@ Zonemaster
 
 Zonemaster
 ----------
-#### 1. Zonemaster c'est quoi ? <a name="q1"></a>
+<a name="q1"></a>
+#### 1. Zonemaster c'est quoi ?
 
 Zonemaster est un outil qui a été créé dans le but d'aider au diagnostic,
 de mesurer et aussi permettre à ses utilisateurs de mieux comprendre le
@@ -44,14 +45,16 @@ IP, de contrôle de validité des signatures DNSSEC...
 L'ensemble des tests réalisés par Zonemaster est décrit au sein du document
 [Test Requirements document](https://github.com/zonemaster/zonemaster/blob/master/docs/requirements/TestRequirements.md).
 
-#### 2. Qui se cache derrière Zonemaster ? <a name="q2"></a>
+<a name="q2"></a>
+#### 2. Qui se cache derrière Zonemaster ?
 
 Zonemaster est un projet conjoint entre l'Afnic (multi-registre français de 
 ccTLDs .fr, .re, .pm, .tf, .wf, .yt et de gTLDs .paris, ...) d'une part et
 [The Swedish Internet Foundation](https://internetstiftelsen.se/en/)
 (registre suédois des ccTLDs .se et .nu) d'autre part.
 
-#### 3. Qu'est-ce que Zonemaster peut faire pour moi ? <a name="q3"></a>
+<a name="q3"></a>
+#### 3. Qu'est-ce que Zonemaster peut faire pour moi ?
 
 Zonemaster a été créé pour un public de techniciens, ou tout du moins pour
 les personnes s'intéressant à la manière dont le DNS fonctionne. Il peut
@@ -62,13 +65,15 @@ analyse. Ainsi, si vous avez demandé une analyse et que vous souhaitez
 montrer à quelqu'un le résultat de celle-ci vous pouvez juste copier le lien
 fourni sur la page des résultats de tests.
 
-#### 4. Zonemaster indique des "Erreurs" ou "Avertissements" sur ma zone. Qu'est ce que cela signifie ? <a name="q4"></a>
+<a name="q4"></a>
+#### 4. Zonemaster indique des "Erreurs" ou "Avertissements" sur ma zone. Qu'est ce que cela signifie ?
 
 Bien évidemment, cela dépend du type des tests qui ont échoué lors de l'analyse
 de la zone. Dans la plupart des cas, vous pouvez cliquer sur le message d'erreur
 ou d'avertissement pour obtenir plus de détails sur le problème qui a été détecté.
 
-#### 5. Comment Zonemaster peut décider ce qui est correct de ce qui ne l'est pas ?  <a name="q5"></a>
+ <a name="q5"></a>
+#### 5. Comment Zonemaster peut décider ce qui est correct de ce qui ne l'est pas ?
 
 Personne ne peut donner de jugement définitif quand à la bonne configuration
 d'une zone (même si certaines erreurs font toutefois consensus). Il est très 
@@ -95,17 +100,20 @@ indiquant ce que vous pensez être incorrect dans notre diagnostique. (Si vous
 ne savez pas quel lien envoyer, consulter la réponse à la question "Qu'est-ce 
 que Zonemaster peut faire pour moi ?" qui se trouve dans cette FAQ)
 
-#### 6. Est-ce que Zonemaster supporte IPv6 ? <a name="q6"></a>
+<a name="q6"></a>
+#### 6. Est-ce que Zonemaster supporte IPv6 ?
 
 Oui, bien sûr. Tous les tests exécutés en IPv4, le seront aussi en IPv6, dans
 la mesure ou Zonemaster est configuré pour le faire.
 
-#### 7. Est-ce que Zonemaster supporte DNSSEC ? <a name="q7"></a>
+<a name="q7"></a>
+#### 7. Est-ce que Zonemaster supporte DNSSEC ?
 
 Oui, si des informations relatives à DNSSEC sont détectées au cours de l'analyse
 de la zone à tester, leur conformité sera automatiquement vérifiée.
 
-#### 8. Qu'est ce qui fait que Zonemaster est différent des outils existants ? <a name="q8"></a>
+<a name="q8"></a>
+#### 8. Qu'est ce qui fait que Zonemaster est différent des outils existants ?
 
 Avant toute chose, Zonemaster conserve un historique des derniers tests 
 réalisés sur une zone. Concrètement, cela signifie que vous pouvez revenir
@@ -127,14 +135,16 @@ Pour finir, cette version "open source" de Zonemaster a été écrite de
 manière modulaire afin de permettre son intégration en tout ou partie dans
 des systèmes existants.
 
-#### 9. Zonemaster et confidentialité <a name="q9"></a>
+<a name="q9"></a>
+#### 9. Zonemaster et confidentialité
 
 Puisque Zonemaster est accessible à tous, n'importe qui, peut vérifier
 votre nom de domaine et consulter les historiques afférents. Toutefois, il
 n'est pas possible de savoir qui a réalisé ces tests puisque cette information
 n'est pas conservée (contrairement à l'heure et au jour du test).
 
-#### 10. Qu'est-ce qui fait que je ne peux pas tester mon nom de domaine ?  <a name="q10"></a>
+ <a name="q10"></a>
+#### 10. Qu'est-ce qui fait que je ne peux pas tester mon nom de domaine ?
 
 Si nous occultons le cas où le nom de domaine n'a pas d'existence au moment 
 où le test est réalisé, il peut y avoir 2 raisons qui peuvent conduire à ce
@@ -160,7 +170,8 @@ résultat:
    contacter si vous pensez que ce problème empêche l'analyse de votre zone.
    Ce contrôle sera amélioré par la suite, nous vous le garantissons.
 
-#### 11. Quels genres de requêtes Zonemaster génère t-il ? <a name="q11"></a>
+<a name="q11"></a>
+#### 11. Quels genres de requêtes Zonemaster génère t-il ?
 
 C'est une question à laquelle il est difficile d'apporter une réponse précise
 puisqu'elle dépend de la configuration de la zone testée mais aussi de la zone
@@ -172,7 +183,8 @@ de manipuler des données liées au DNS quotidiennement, ce niveau de détail
 pourra être considéré trop technique et réservé à un public averti, les autres 
 pourront se contenter de l'interface "classique".
 
-#### 12. C'est quoi un test sur un nom de domaine non délégué ? <a name="q12"></a>
+<a name="q12"></a>
+#### 12. C'est quoi un test sur un nom de domaine non délégué ?
 
 On va appeler, test sur un nom de domaine non délégué, un test réalisé sur
 une zone non complètement publiée dans le DNS. Cela est particulièrement
@@ -186,7 +198,8 @@ effectué. Un résultat d'analyse positif (toutes les catégories de résultat
 aparaissent en vert) vous permet d'être à peu près certain que le nouveau 
 serveur est correctement configuré. 
 
-#### 13. Comment tester une zone "reverse" avec Zonemaster ? <a name="q13"></a>
+<a name="q13"></a>
+#### 13. Comment tester une zone "reverse" avec Zonemaster ?
 
 Zonemaster peut être utilisé pour valider un certain nombre d'éléments lors
 de la configuration d'une zone. Parmi ces éléments, il y a les vérifications

--- a/docs/FAQ/gui-faq-sv.md
+++ b/docs/FAQ/gui-faq-sv.md
@@ -18,7 +18,8 @@ Zonemaster
 Zonemaster
 ----------
 
-#### 1. Vad är Zonemaster? <a name="q1"></a>
+<a name="q1"></a>
+#### 1. Vad är Zonemaster?
 
 Zonemaster är ett program som är framtaget för att hjälpa människor att kontrollera, mäta och förhoppningsvis också bättre förstå hur DNS, domain name system, fungerar. Zonemaster består av 3 huvuddelar: 
 1. "Engine" - en testmotor som genomför alla DNS-tester. 
@@ -28,13 +29,15 @@ Zonemaster är ett program som är framtaget för att hjälpa människor att kon
 
 När en domän (även kallad zon) skickas till Zonemaster så kommer programmet att undersöka domänens hälsotillstånd genom att gå igenom DNS från roten (.) till TLD:n (toppdomänen, till exempel .NET) och till slut de DNS-servrar som innehåller information om den specificerade domänen (till exempel zonemaster.net). Zonemaster utför även en hel del andra tester och alla dessa är dokumenterade här: [Test Requirements document](https://github.com/zonemaster/zonemaster/blob/master/docs/requirements/TestRequirements.md)
 
-#### 2. Vem står bakom Zonemaster? <a name="q2"></a>
+<a name="q2"></a>
+#### 2. Vem står bakom Zonemaster?
 
 Zonemaster är ett samarbetsprojekt mellan [Internetstiftelsen](https://internetstiftelsen.se/)
 (registry för .se och .nu) och [AFNIC](https://www.afnic.fr/en/)
 (registry för .fr och andra TLD:er som .re, .pm, .tf, .wf, .yt samt .paris).
 
-#### 3. Hur kan Zonemaster hjälpa mig? <a name="q3"></a>
+<a name="q3"></a>
+#### 3. Hur kan Zonemaster hjälpa mig?
 
 Zonemaster är framtaget för två kategorier av användare:
 
@@ -45,11 +48,13 @@ Zonemaster är framtaget för två kategorier av användare:
 Användare av den andra kategorin bör vända sig till sin DNS-operatör
 så fort något inte lyser "grönt" vid en test.
 
-#### 4. Zonemaster visar "Fel"/"Varning" när jag testar min domän, vad betyder det? <a name="q4"></a>
+<a name="q4"></a>
+#### 4. Zonemaster visar "Fel"/"Varning" när jag testar min domän, vad betyder det?
 
 Det beror på vilket test det gäller.
 
-#### 5. Hur kan Zonemaster bedömma vad som är rätt och fel? <a name="q5"></a>
+<a name="q5"></a>
+#### 5. Hur kan Zonemaster bedömma vad som är rätt och fel?
 
 Ingen kan ge ett definitivt, slutgiltigt utlåtande om en domäns hälsa. Detta är 
 viktigt att poängtera. Vi som står bakom Zonemaster påstår inte 
@@ -67,15 +72,18 @@ vi felbedömt, tveka då inte att kontakta oss på zonemaster-devel@lists.iis.se
 länk till ditt test och en förklaring av varför du anser att resultatet inte är
 korrekt. 
 
-#### 6. Kan Zonemaster hantera IPv6? <a name="q6"></a>
+<a name="q6"></a>
+#### 6. Kan Zonemaster hantera IPv6?
 
 Ja. Alla tester som körs över IPv4 kommer även köras över IPv6 om Zonemaster är konfigurerad att göra det.
 
-#### 7. Kan Zonemaster hantera DNSSEC? <a name="q7"></a>
+<a name="q7"></a>
+#### 7. Kan Zonemaster hantera DNSSEC?
 
 Ja. Om en domän som testas av Zonemaster har DNSSEC konfigurerat så kommer det testas automatiskt.
 
-#### 8. Vad skiljer Zonemaster från annan mjukvara som testar domäner? <a name="q8"></a>
+<a name="q8"></a>
+#### 8. Vad skiljer Zonemaster från annan mjukvara som testar domäner?
 För det första så sparar Zonemaster all testhistoria. Det innebär att du kan gå tillbaka och titta på ett test du gjorde för en vecka sedan och jämföra det med ett test du nyss gjorde.
 
 Alla test som Zonemaster kör är definierade i testfallsspecifikationer som
@@ -87,11 +95,13 @@ Zonemaster kan också testa icke-publicerade/odelegerade domäner (mer om detta 
 Zonemaster är dessutom öppen källkod och är modulärt uppbyggd. Du kan med andra ord återanvända
 hela eller delar av koden i dina egna system om du vill.
 
-#### 9. Zonemaster och integritet <a name="q9"></a>
+<a name="q9"></a>
+#### 9. Zonemaster och integritet
 
 Eftersom Zonemaster är tillgänglig för alla är det också möjligt för vem som helst att kontrollera din domän och också se testhistoria för din domän. Det finns dock inget sätt att se vem som har gjort ett test eftersom det enda som loggas är tidpunken då testet gjordes.
 
-#### 10. Varför kan jag inte testa min domän? <a name="q10"></a>
+<a name="q10"></a>
+#### 10. Varför kan jag inte testa min domän?
 
 Om vi utgår från att domänen du försöker testa faktiskt existerar så finns det två saker som kan orsaka detta:
 
@@ -101,7 +111,8 @@ Om vi utgår från att domänen du försöker testa faktiskt existerar så finns
 inte värdnamn i en zon eller domän (som www.zonemaster.net) så kommer Zonemaster att rapportera det som
 ett misslyckande om man försöker att testa ett domännamn som inte motsvarar en DNS-zon.
 
-#### 11. Vilken typ av DNS-frågor genererar Zonemaster? <a name="q11"></a>
+<a name="q11"></a>
+#### 11. Vilken typ av DNS-frågor genererar Zonemaster?
 
 Det här är en svår fråga att svara på eftersom Zonemaster kommer att generera olika typer av anrop
 beroende på hur dina DNS-servrar svarar.
@@ -110,7 +121,8 @@ Det enklaste sättet att se exakt vad Zonemaster testar är att köra ”zonemas
 (och för att göra det så måste du ladda ner och installera det) och välja full utskrift.
 Programmets utskrift ger grundlig information om vad som händer under testet, men är också tekniskt utmanande.
 
-#### 12. Vad är ett odelegerat domäntest? <a name="q12"></a>
+<a name="q12"></a>
+#### 12. Vad är ett odelegerat domäntest?
 
 Ett odelegerat domäntest är ett test som genomförs på en domän som inte nödvändigtvis
 måste vara publicerad i DNS.
@@ -125,7 +137,8 @@ domän fungerar som den ska.
 Det kan emellertid fortfarande finnas fel i zoninformationen som detta test inte känner
 till.
 
-#### 13. Hur kan jag testa en domän som är en baklängesuppslagningsdomän? <a name="q13"></a>
+<a name="q13"></a>
+#### 13. Hur kan jag testa en domän som är en baklängesuppslagningsdomän?
 För att kunna kontrolla en reverszon så måste du veta vilken den är. Om du vill kontrollera
 en reverszon så matar du in det format som används i DNS, t.ex.:
 

--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -67,12 +67,13 @@ translate the file using English as the model.
 It is important to preserve the structure of the file. There must be a
 table of contents linking to the question plus answer below. The anchor
 names must be "q1" etc and nothing else. There are links in the code
-that assume this model.
+that assume this model, where the `<a>` tag is just before the heading.
 
 ```
 1. [What is Zonemaster?](#q1)
 
-#### 1. What is Zonemaster? <a name="q1"></a>
+<a name="q1"></a>
+#### 1. What is Zonemaster?
 ```
 
 ## Add the language to HTML code

--- a/src/app/components/faq/faq.component.css
+++ b/src/app/components/faq/faq.component.css
@@ -1,3 +1,8 @@
 :host ::ng-deep a {
   color: #000;
 }
+
+:host ::ng-deep a[name^=q] {
+  position: relative;
+  top: -90px;
+}


### PR DESCRIPTION
As stated in #149, when using the FAQ table of content to go to a specific section, the section title is hidden behind the navbar. This is a tweak to avoid this behavior. And unlike stated in #149, this affects all devices (not only small end devices).

Fixes #149 

### How to test this PR

Before :

1. go to the FAQ : https://zonemaster.net/faq
2. reduce the size of your browser
3. choose a section for instance section 6 : https://zonemaster.net/faq#q6
4. part or all the section is hidden behind the navbar

With this PR :

4. the section now appears below the navbar