### PR TITLE
Updated e2e language tests

### DIFF
--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -19,7 +19,9 @@ following languages with the attached language code:
 
 * `da` for Danish language
 * `en` for English language
+* `fi` for Finnish language
 * `fr` for French language
+* `nb` for Norwegian language
 * `sv` for Swedish language
 
 
@@ -116,7 +118,7 @@ The new language must be added to the following files:
 In `package.json` locate
 
 ```
-    "i18n:extract": "ngx-translate-extract --input ./src --output ./src/assets/i18n/{da,en,fr,sv}.json --key-as-default-value --clean --sort --format json"
+    "i18n:extract": "ngx-translate-extract --input ./src --output ./src/assets/i18n/{da,en,fi,fr,nb,sv}.json --key-as-default-value --clean --sort --format json"
 ```
 and add the two-letter language code of the new language. Preserve
 the alphabetical order of the language codes.
@@ -141,10 +143,17 @@ In `navigation.component.ts` locate
 
 ```
   private isValidLanguage(lang: string) {
-    const validLanguages = [ 'da', 'en', 'fr', 'sv' ];
+    const validLanguages = [ 'da', 'en', 'fi', 'fr', 'nb', 'sv' ];
 ```
 and add the two-letter language code of the new language. Preserve
 the alphabetical order of the language codes.
+
+## Add e2e test script for the language
+
+Create a new `FR05-xx.e2e-spec.ts` e2e test script in the [e2e] folder
+where `xx` is the language code of the new language. Copy
+[FR05-en.e2e-spec.ts] and modify to create a correct test file for
+the new language.
 
 
 ## Change default language
@@ -166,6 +175,8 @@ is updated.
 
 [ISO 639-1]:                                               https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 [docs/FAQ]:                                                FAQ
+[e2e]:                                                     ../e2e
+[FR05-en.e2e-spec.ts]:                                     ../e2e/FR05-en.e2e-spec.ts
 [package.json]:                                            ../package.json
 [src/app/app.module.ts]:                                   ../src/app/app.module.ts
 [src/app/components/navigation/navigation.component.html]: ../src/app/components/navigation/navigation.component.html

--- a/e2e/FR05-da.e2e-spec.ts
+++ b/e2e/FR05-da.e2e-spec.ts
@@ -1,0 +1,20 @@
+import { by, browser, element } from 'protractor';
+
+import { Utils } from './utils/app.utils';
+
+describe('Zonemaster test FR05-da - [Supports Danish language]', () => {
+  const utils = new Utils();
+  beforeAll(() => {
+    utils.goToHome();
+  });
+
+  it('should have Danish language button', () => {
+    expect(element(by.xpath('//a[@lang="da"]')).isPresent()).toBe(true);
+  });
+
+  it('should switch to Danish', () => {
+    utils.setLang('da');
+    expect(element(by.xpath('//h1[.="Domænenavn"]')).isPresent()).toBe(true);
+  });
+});
+

--- a/e2e/FR05-en.e2e-spec.ts
+++ b/e2e/FR05-en.e2e-spec.ts
@@ -2,7 +2,7 @@ import { by, browser, element } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
-describe('Zonemaster test FR07 - [Supports English language]', () => {
+describe('Zonemaster test FR05-en - [Supports English language]', () => {
   const utils = new Utils();
   beforeAll(() => {
     utils.goToHome();

--- a/e2e/FR05-fi.e2e-spec.ts
+++ b/e2e/FR05-fi.e2e-spec.ts
@@ -1,0 +1,20 @@
+import { by, browser, element } from 'protractor';
+
+import { Utils } from './utils/app.utils';
+
+describe('Zonemaster test FR05-fi - [Supports Finnish language]', () => {
+  const utils = new Utils();
+  beforeAll(() => {
+    utils.goToHome();
+  });
+
+  it('should have Finnish language button', () => {
+    expect(element(by.xpath('//a[@lang="fi"]')).isPresent()).toBe(true);
+  });
+
+  it('should switch to Finnish', () => {
+    utils.setLang('fi');
+    expect(element(by.xpath('//h1[.="Verkkotunnus"]')).isPresent()).toBe(true);
+  });
+});
+

--- a/e2e/FR05-fr.e2e-spec.ts
+++ b/e2e/FR05-fr.e2e-spec.ts
@@ -2,7 +2,7 @@ import { by, browser, element } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
-describe('Zonemaster test FR06-fr - [Supports French language]', () => {
+describe('Zonemaster test FR05-fr - [Supports French language]', () => {
 
   const utils = new Utils();
 

--- a/e2e/FR05-fr.e2e-spec.ts
+++ b/e2e/FR05-fr.e2e-spec.ts
@@ -2,7 +2,7 @@ import { by, browser, element } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
-describe('Zonemaster test FR06 - [Supports French language]', () => {
+describe('Zonemaster test FR06-fr - [Supports French language]', () => {
 
   const utils = new Utils();
 

--- a/e2e/FR05-nb.e2e-spec.ts
+++ b/e2e/FR05-nb.e2e-spec.ts
@@ -1,0 +1,20 @@
+import { by, browser, element } from 'protractor';
+
+import { Utils } from './utils/app.utils';
+
+describe('Zonemaster test FR05-nb - [Supports Norwegian language]', () => {
+  const utils = new Utils();
+  beforeAll(() => {
+    utils.goToHome();
+  });
+
+  it('should have Norwegian language button', () => {
+    expect(element(by.xpath('//a[@lang="nb"]')).isPresent()).toBe(true);
+  });
+
+  it('should switch to Norwegian', () => {
+    utils.setLang('nb');
+    expect(element(by.xpath('//h1[.="Domenenavn"]')).isPresent()).toBe(true);
+  });
+});
+

--- a/e2e/FR05-sv.e2e-spec.ts
+++ b/e2e/FR05-sv.e2e-spec.ts
@@ -2,7 +2,7 @@ import { by, browser, element } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
-describe('Zonemaster test FR05 - [Supports Swedish language]', () => {
+describe('Zonemaster test FR05-sv - [Supports Swedish language]', () => {
   const utils = new Utils();
   beforeAll(() => {
     utils.goToHome();


### PR DESCRIPTION
* Added test script for da (Danish) language
* Added test script for fi (Finnish) language
* Added test script for nb (Norwegian) language
* Renamed language test scripts to be FR05-xx to make it possible
  to expand with new language and keep them in sequence

Partially resolves request in https://github.com/zonemaster/zonemaster-gui/pull/174#pullrequestreview-633479423