### PR TITLE
CentOS installation

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -35,7 +35,7 @@ This instruction covers the following operating systems:
 
 ```sh
 sudo yum update
-sudo yum install httpd
+sudo yum -y install httpd unzip
 ```
 
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -186,13 +186,16 @@ Use the procedure for installation on [Debian](#2-debian).
 
 ## Post-installation sanity check
 
-Point your browser at `http://localhost/` (or the address of the server where
-you installed Zonemaster Web GUI).
+Make sure Zonemaster-GUI is properly installed.
 
-Verify that the Zonemaster Web GUI is shown with the text "Program versions" in
-its page footer.
-Verify that when you mouse over this text the versions of the following
-Zonemaster components are shown: Backend, Engine and GUI.
+1. Point your browser at `http://localhost/` (or the address of the server where
+   you installed Zonemaster Web GUI).
+
+2. Verify that the Zonemaster Web GUI is shown with the text "Program versions" in
+   its page footer.
+
+3. Verify that when you mouse over this text the versions of the following
+   Zonemaster components are shown: Backend, Engine and GUI.
 
 
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -189,8 +189,10 @@ Use the procedure for installation on [Debian](#2-debian).
 Point your browser at `http://localhost/` (or the address of the server where
 you installed Zonemaster Web GUI).
 
-Verify that the Zonemaster Web GUI is shown with the " Version used " in its page footer.
-And when the mouse over this text, it display all version of the zonemaster stack (Backend, Engine and GUI).
+Verify that the Zonemaster Web GUI is shown with the text "Program versions" in
+its page footer.
+Verify that when you mouse over this text the versions of the following
+Zonemaster components are shown: Backend, Engine and GUI.
 
 
 

--- a/zonemaster.conf-example
+++ b/zonemaster.conf-example
@@ -1,18 +1,18 @@
 <VirtualHost *:80>
-	DocumentRoot /var/www/html/zonemaster-web-gui/dist
-	DirectoryIndex index.html
-	ServerAdmin example@example.net
+  DocumentRoot /var/www/html/zonemaster-web-gui/dist
+  DirectoryIndex index.html
+  ServerAdmin example@example.net
 
-	<Directory "/var/www/html/zonemaster-web-gui/dist">
-		Options Indexes MultiViews FollowSymlinks Includes
-		AllowOverride All
-		Require all granted
-	</Directory>
+  <Directory "/var/www/html/zonemaster-web-gui/dist">
+    Options Indexes MultiViews FollowSymlinks Includes
+    AllowOverride All
+    Require all granted
+  </Directory>
 
-	ProxyPass /api http://localhost:5000/
+  ProxyPass /api http://localhost:5000/
   ProxyPassReverse /api http://localhost:5000/
   ProxyPreserveHost On
 
-	ErrorLog  /var/log/zonemaster/zonemaster-web-gui-error.log
-	CustomLog /var/log/zonemaster/zonemaster-web-gui-access_log common
+  ErrorLog  /var/log/zonemaster/zonemaster-web-gui-error.log
+  CustomLog /var/log/zonemaster/zonemaster-web-gui-access_log common
 </VirtualHost>


### PR DESCRIPTION
## Purpose

Some fixes and cleaning up.

## Changes

Installation of unzip is added to the CentOS installation. It's needed to extract the dist tarball.

The smoke test instruction was outdated in terms of what to look for to verify success. This PR fixes that.

Whitespace in a sample file is updated to use spaces instead of tabs.

## How to test this PR

This PR is tested implicitly as part of installation testing.