### PR TITLE
Follow Github redirection in Installation instruction

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -42,7 +42,7 @@ sudo yum -y install httpd unzip
 #### Install Zonemaster Web GUI
 
 ```sh
-curl -O https://github.com/zonemaster/zonemaster-gui/releases/download/v3.3.0/zonemaster_web_gui.zip
+curl -L -O https://github.com/zonemaster/zonemaster-gui/releases/download/v3.3.0/zonemaster_web_gui.zip
 sudo install -vd /var/www/html/zonemaster-web-gui
 sudo install -vd /var/log/zonemaster
 sudo unzip -d /var/www/html/zonemaster-web-gui zonemaster_web_gui.zip


### PR DESCRIPTION
## Purpose

When downloading the zip file, we should follow redirection set by Github in order to get the zip file and not an HTML file.

## Changes

Updates an Installation command.

## How to test this PR

Before:
1. run `curl -O https://github.com/zonemaster/zonemaster-gui/releases/download/v3.3.0/zonemaster_web_gui.zip`
2. `file zonemaster_web_gui.zip` gives `HTML document`

After :
1. run `curl -L -O https://github.com/zonemaster/zonemaster-gui/releases/download/v3.3.0/zonemaster_web_gui.zip`
2. `file zonemaster_web_gui.zip` gives `Zip archive data`