### PR TITLE
Update copyright year to 2021

### DIFF
--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -20,7 +20,7 @@
 
     <div class="row">
       <div class="col-md-12">
-        <p class="copyright text-muted small">Copyright &copy; AFNIC and The Swedish Internet Foundation, 2018-2020. All Rights Reserved</p>
+        <p class="copyright text-muted small">Copyright &copy; AFNIC and The Swedish Internet Foundation, 2018-2021. All Rights Reserved</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Purpose

The copyright statement is still 2020. This updates it to 2021.

## Context

Addresses #188 (well not exactly because the issue is about to dynamically setting the year).

## Changes

Update the footer component inner HTML.

## How to test this PR

Look that the copyright statement displays the current year.

## Final note

I am no jurist, but do we really need this copyright statement ?
