### PR TITLE
Makes DS hash algorithm number explicit

### DIFF
--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -135,10 +135,10 @@
                 </select>
                 <select formControlName="digtype" class="form-control" name="form.digtype">
                   <option [value]="-1" selected disabled hidden> {{'Digest type' | translate}} </option>
-                  <option [value]="1">SHA-1</option>
-                  <option [value]="2">SHA-256</option>
-                  <option [value]="3">GOST R 34.11-94</option>
-                  <option [value]="4">SHA-384</option>
+                  <option [value]="1">1 - SHA-1</option>
+                  <option [value]="2">2 - SHA-256</option>
+                  <option [value]="3">3 - GOST R 34.11-94</option>
+                  <option [value]="4">4 - SHA-384</option>
                 </select>
                 <input formControlName="digest" class="form-control" name="digest" placeholder="{{'Digest' | translate}}">
                 <button


### PR DESCRIPTION
## Purpose

The hash algorithm for DS is often displayed as a number, e.g. with `dig`. In the GUI when you do a undelegated test and select DS parameter the hash algorithm is selected by name. It should be possible to start with the algorithm code.

## Changes

This RP updates the select list so that the hash algorithm code is also shown. The solution is the same as for the DNSKEY algorithm select list.

## How to test this PR

Verify that correct algorithm is selected.