### PR TITLE
update client version in mock

### DIFF
--- a/e2e/FR22.e2e-spec.ts
+++ b/e2e/FR22.e2e-spec.ts
@@ -23,6 +23,6 @@ describe('Zonemaster test FR22 - [Provide the possibility to see more informatio
     await expect(element(by.css('#collapsed_module_1')).getText()).toEqual('BASIC');
     await expect(element.all(by.css('#collapsed_module_1 > tr.show')).count()).toBe(0);
     await element(by.css('#collapsed_module_1 > tr:nth-child(1)')).click();
-    await expect(element.all(by.css('#collapsed_module_1 > tr.show')).count()).toEqual(8);
+    await expect(element.all(by.css('#collapsed_module_1 > tr.show')).count()).toEqual(14);
   });
 });

--- a/src/app/interceptors/mock.interceptor.ts
+++ b/src/app/interceptors/mock.interceptor.ts
@@ -1,6 +1,8 @@
 import { Injectable, Injector } from '@angular/core';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
+import { environment } from '../../environments/environment';
+
 
 const urls = [
   {
@@ -8,7 +10,7 @@ const urls = [
     body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
       {
         'ipv4': true, 'ipv6': true, 'profile': 'default', 'domain': 'afNiC.Fr',
-        'ds_info': [], 'nameservers': [], 'client_version': '3.3.0', 'client_id': 'Zonemaster GUI'
+        'ds_info': [], 'nameservers': [], 'client_version': environment.clientInfo.version, 'client_id': environment.clientInfo.id
       }
     },
     method: 'POST',

--- a/src/app/interceptors/mock.interceptor.ts
+++ b/src/app/interceptors/mock.interceptor.ts
@@ -8,7 +8,7 @@ const urls = [
     body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
       {
         'ipv4': true, 'ipv6': true, 'profile': 'default', 'domain': 'afNiC.Fr',
-        'ds_info': [], 'nameservers': [], 'client_version': '3.1.0', 'client_id': 'Zonemaster GUI'
+        'ds_info': [], 'nameservers': [], 'client_version': '3.3.0', 'client_id': 'Zonemaster GUI'
       }
     },
     method: 'POST',


### PR DESCRIPTION

## Purpose

As the client version changed, the `start_domain_test` request was not mocked resulting on all subsequent request to not be mocked as well.

## Context

The e2e test FR22 start a test, all request to the API are intercepted and the ones that matches (equality check) the requests in mock.interceptor.ts are mocked. As the client version is part of the request not having the same will result in the requests not being mocked during the tests, which can lead to inconsistency.

## Changes

Use the current client version/id in the interceptor.

## How to test this PR

`npm run ng e2e -- --webdriver-update=false --specs=e2e/FR22.e2e-spec.ts`