### PR TITLE
Improve language selection nav

### DIFF
--- a/e2e/FR05-da.e2e-spec.ts
+++ b/e2e/FR05-da.e2e-spec.ts
@@ -4,17 +4,19 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR05-da - [Supports Danish language]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
+  beforeAll(async () => {
+    await utils.goToHome();
   });
 
   it('should have Danish language button', () => {
     expect(element(by.xpath('//a[@lang="da"]')).isPresent()).toBe(true);
   });
 
-  it('should switch to Danish', () => {
-    utils.setLang('da');
+  it('should switch to Danish', async () => {
+    await utils.setLang('da');
     expect(element(by.xpath('//h1[.="Domænenavn"]')).isPresent()).toBe(true);
+    const selectedLang = element.all(by.css('nav div.lang a.selected'));
+    expect(selectedLang.count()).toBe(1);
+    expect(selectedLang.first().getAttribute('lang')).toBe('da');
   });
 });
-

--- a/e2e/FR05-en.e2e-spec.ts
+++ b/e2e/FR05-en.e2e-spec.ts
@@ -4,16 +4,19 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR05-en - [Supports English language]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
+  beforeAll(async () => {
+    await utils.goToHome();
   });
 
   it('should have English language button', () => {
     expect(element(by.xpath('//a[@lang="en"]')).isPresent()).toBe(true);
   });
 
-  it('should switch to English', () => {
-    utils.setLang('en');
+  it('should switch to English', async () => {
+    await utils.setLang('en');
     expect(element(by.xpath('//h1[.="Domain name"]')).isPresent()).toBe(true);
+    const selectedLang = element.all(by.css('nav div.lang a.selected'));
+    expect(selectedLang.count()).toBe(1);
+    expect(selectedLang.first().getAttribute('lang')).toBe('en');
   });
 });

--- a/e2e/FR05-fi.e2e-spec.ts
+++ b/e2e/FR05-fi.e2e-spec.ts
@@ -4,17 +4,19 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR05-fi - [Supports Finnish language]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
+  beforeAll(async () => {
+    await utils.goToHome();
   });
 
   it('should have Finnish language button', () => {
     expect(element(by.xpath('//a[@lang="fi"]')).isPresent()).toBe(true);
   });
 
-  it('should switch to Finnish', () => {
-    utils.setLang('fi');
+  it('should switch to Finnish', async () => {
+    await utils.setLang('fi');
     expect(element(by.xpath('//h1[.="Verkkotunnus"]')).isPresent()).toBe(true);
+    const selectedLang = element.all(by.css('nav div.lang a.selected'));
+    expect(selectedLang.count()).toBe(1);
+    expect(selectedLang.first().getAttribute('lang')).toBe('fi');
   });
 });
-

--- a/e2e/FR05-fr.e2e-spec.ts
+++ b/e2e/FR05-fr.e2e-spec.ts
@@ -6,16 +6,19 @@ describe('Zonemaster test FR05-fr - [Supports French language]', () => {
 
   const utils = new Utils();
 
-  beforeAll(() => {
-    utils.goToHome();
+  beforeAll(async () => {
+    await utils.goToHome();
   });
 
   it('should have French language button', () => {
     expect(element(by.xpath('//a[@lang="fr"]')).isPresent()).toBe(true);
   });
 
-  it('should switch to French', () => {
-    utils.setLang('fr');
+  it('should switch to French', async () => {
+    await utils.setLang('fr');
     expect(element(by.xpath('//h1[.="Nom de domaine"]')).isPresent()).toBe(true);
+    const selectedLang = element.all(by.css('nav div.lang a.selected'));
+    expect(selectedLang.count()).toBe(1);
+    expect(selectedLang.first().getAttribute('lang')).toBe('fr');
   });
 });

--- a/e2e/FR05-nb.e2e-spec.ts
+++ b/e2e/FR05-nb.e2e-spec.ts
@@ -4,17 +4,19 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR05-nb - [Supports Norwegian language]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
+  beforeAll(async () => {
+    await utils.goToHome();
   });
 
   it('should have Norwegian language button', () => {
     expect(element(by.xpath('//a[@lang="nb"]')).isPresent()).toBe(true);
   });
 
-  it('should switch to Norwegian', () => {
-    utils.setLang('nb');
+  it('should switch to Norwegian', async () => {
+    await utils.setLang('nb');
     expect(element(by.xpath('//h1[.="Domenenavn"]')).isPresent()).toBe(true);
+    const selectedLang = element.all(by.css('nav div.lang a.selected'));
+    expect(selectedLang.count()).toBe(1);
+    expect(selectedLang.first().getAttribute('lang')).toBe('nb');
   });
 });
-

--- a/e2e/FR05-sv.e2e-spec.ts
+++ b/e2e/FR05-sv.e2e-spec.ts
@@ -4,17 +4,19 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR05-sv - [Supports Swedish language]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
+  beforeAll(async () => {
+    await utils.goToHome();
   });
 
   it('should have Swedish language button', () => {
     expect(element(by.xpath('//a[@lang="sv"]')).isPresent()).toBe(true);
   });
 
-  it('should switch to Swedish', () => {
-    utils.setLang('sv');
+  it('should switch to Swedish', async () => {
+    await utils.setLang('sv');
     expect(element(by.xpath('//h1[.="Domännamn"]')).isPresent()).toBe(true);
+    const selectedLang = element.all(by.css('nav div.lang a.selected'));
+    expect(selectedLang.count()).toBe(1);
+    expect(selectedLang.first().getAttribute('lang')).toBe('sv');
   });
 });
-

--- a/e2e/FR16.e2e-spec.ts
+++ b/e2e/FR16.e2e-spec.ts
@@ -19,14 +19,11 @@ describe('Zonemaster test FR16 - [The advanced view should have a text describin
   it('should have a description text in multi languages', async () => {
     await utils.setLang('en');
     expect(element(by.css('.alert.alert-info')).element(by.css('a')).getText()).toContain('undelegated');
-    expect(element(by.css('nav div.lang a.selected')).getAttribute('lang')).toBe('en');
 
     await utils.setLang('fr');
     expect(element(by.css('.alert.alert-info')).element(by.css('a')).getText()).toContain('non délégué');
-    expect(element(by.css('nav div.lang a.selected')).getAttribute('lang')).toBe('fr');
 
     await utils.setLang('sv');
     expect(element(by.css('.alert.alert-info')).element(by.css('a')).getText()).toContain('odelegerat domäntest');
-    expect(element(by.css('nav div.lang a.selected')).getAttribute('lang')).toBe('sv');
   });
 });

--- a/e2e/FR16.e2e-spec.ts
+++ b/e2e/FR16.e2e-spec.ts
@@ -4,10 +4,10 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR16 - [The advanced view should have a text describing what undelegated means?]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
-    utils.activeOptions();
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
+    await utils.activeOptions();
   });
 
   it('should have a link to the proper faq answer', () => {
@@ -16,12 +16,17 @@ describe('Zonemaster test FR16 - [The advanced view should have a text describin
     expect(element(by.css('.alert.alert-info')).element(by.css('a')).getAttribute('fragment')).toBe('q12');
   });
 
-  it('should have a description text in multi languages', () => {
-    utils.setLang('en');
+  it('should have a description text in multi languages', async () => {
+    await utils.setLang('en');
     expect(element(by.css('.alert.alert-info')).element(by.css('a')).getText()).toContain('undelegated');
-    utils.setLang('fr');
+    expect(element(by.css('nav div.lang a.selected')).getAttribute('lang')).toBe('en');
+
+    await utils.setLang('fr');
     expect(element(by.css('.alert.alert-info')).element(by.css('a')).getText()).toContain('non délégué');
-    utils.setLang('sv');
+    expect(element(by.css('nav div.lang a.selected')).getAttribute('lang')).toBe('fr');
+
+    await utils.setLang('sv');
     expect(element(by.css('.alert.alert-info')).element(by.css('a')).getText()).toContain('odelegerat domäntest');
+    expect(element(by.css('nav div.lang a.selected')).getAttribute('lang')).toBe('sv');
   });
 });

--- a/e2e/utils/app.utils.ts
+++ b/e2e/utils/app.utils.ts
@@ -1,4 +1,4 @@
-import { element, browser, by } from 'protractor';
+import { element, browser, by, ExpectedConditions, $ } from 'protractor';
 
 export class Utils {
   goToHome() {
@@ -10,11 +10,12 @@ export class Utils {
   }
 
   setLang(lang) {
-    element(by.xpath('//a[@lang="' + lang + '"]')).click();
+    return element(by.xpath('//a[@lang="' + lang + '"]')).click()
+      .then(() => browser.wait(ExpectedConditions.presenceOf($(`.lang > div > a.selected[lang="${lang}"]`)), 10000))
   }
 
   activeOptions() {
-    element(by.css('.switch')).click();
+    return element(by.css('.switch')).click();
   }
 
   getPageTitle() {

--- a/e2e/utils/app.utils.ts
+++ b/e2e/utils/app.utils.ts
@@ -11,7 +11,7 @@ export class Utils {
 
   setLang(lang) {
     return element(by.xpath('//a[@lang="' + lang + '"]')).click()
-      .then(() => browser.wait(ExpectedConditions.presenceOf($(`.lang > div > a.selected[lang="${lang}"]`)), 10000))
+      .then(() => browser.wait(ExpectedConditions.presenceOf($(`.lang > div > a.selected[lang="${lang}"]`)), 10000));
   }
 
   activeOptions() {

--- a/src/app/components/navigation/navigation.component.css
+++ b/src/app/components/navigation/navigation.component.css
@@ -6,6 +6,10 @@
   cursor: pointer;
 }
 
+.lang > div > a.selected {
+  font-weight: bold;
+}
+
 nav {
   box-shadow: 0px 7px 5px -9px rgba(0,0,0,0.75);
   -webkit-transition:0.5s linear all;

--- a/src/app/components/navigation/navigation.component.css
+++ b/src/app/components/navigation/navigation.component.css
@@ -8,6 +8,7 @@
 
 .lang > div > a.selected {
   font-weight: bold;
+  text-decoration: underline solid 1px;
 }
 
 nav {

--- a/src/app/components/navigation/navigation.component.css
+++ b/src/app/components/navigation/navigation.component.css
@@ -4,6 +4,7 @@
 
 .lang > div > a {
   cursor: pointer;
+  color: inherit;
 }
 
 .lang > div > a.selected {

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -23,12 +23,12 @@
 
       <div class="lang">
         <div class="d-none d-sm-block">
-          <a lang='da' (click)="setLanguage('da')">Da</a> |
-          <a lang='en' (click)="setLanguage('en')">En</a> |
-          <a lang='fi' (click)="setLanguage('fi')">Fi</a> |
-          <a lang='fr' (click)="setLanguage('fr')">Fr</a> |
-          <a lang='nb' (click)="setLanguage('nb')">Nb</a> |
-          <a lang='sv' (click)="setLanguage('sv')">Sv</a> &nbsp;
+          <a lang='da' (click)="setLanguage('da')" title="Dansk" [class.selected]="lang==='da'">Da</a> |
+          <a lang='en' (click)="setLanguage('en')" title="English" [class.selected]="lang==='en'">En</a> |
+          <a lang='fi' (click)="setLanguage('fi')" title="Suomi" [class.selected]="lang==='fi'">Fi</a> |
+          <a lang='fr' (click)="setLanguage('fr')" title="Français" [class.selected]="lang==='fr'">Fr</a> |
+          <a lang='nb' (click)="setLanguage('nb')" title="Norsk (bokmål)" [class.selected]="lang==='nb'">Nb</a> |
+          <a lang='sv' (click)="setLanguage('sv')" title="Svenska" [class.selected]="lang==='sv'">Sv</a> &nbsp;
         </div>
         <div class="d-sm-none">
           <select name="lang" [(ngModel)]="lang" (change)="setLanguage(lang)" class="form-control" id="languageSelection">
@@ -59,4 +59,3 @@
 <button (click)="backToTop()" class="btn btn-primary btn-lg" [ngClass]="{'d-none': !activeBackToTop, 'back-to-top': activeBackToTop}" role="button" title="Click to return on the top page" data-toggle="tooltip" data-placement="left">
   <i class="fa fa-arrow-up" aria-hidden="true"></i>
 </button>
-

--- a/src/app/components/navigation/navigation.component.ts
+++ b/src/app/components/navigation/navigation.component.ts
@@ -48,8 +48,9 @@ export class NavigationComponent implements OnInit {
   }
 
   public setLanguage(lang: string) {
-    this.lang = lang;
-    this.translateService.use(lang);
+    this.translateService.use(lang).subscribe(() => {
+      this.lang = lang;
+    });
   }
 
   private isValidLanguage(lang: string) {

--- a/src/app/components/navigation/navigation.component.ts
+++ b/src/app/components/navigation/navigation.component.ts
@@ -48,6 +48,7 @@ export class NavigationComponent implements OnInit {
   }
 
   public setLanguage(lang: string) {
+    this.lang = lang;
     this.translateService.use(lang);
   }
 


### PR DESCRIPTION
## Purpose

Improve language selection nav on wide screens.

Some tests (FR16) are failing because the lang has not been changed when the test is conducted. Tries to wait (after the selected language has changed) for the translation to be effective before continuing. (replace #225)

## Context

Addresses #212, #213 and #223.

## Changes

![Screenshot_20210615_113053](https://user-images.githubusercontent.com/19394895/122029512-38363b00-cdcd-11eb-8ccf-81e3808a68c8.png)


## How to test this PR

* Change languages and hover links.
* `npm run ng e2e -- --webdriver-update=false --specs=e2e/FR16.e2e-spec.ts `
* `npm run ng e2e -- --webdriver-update=false --specs='e2e/FR05-*.ts'`
