### PR TITLE
Fix DS placeholder

### DIFF
--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -112,7 +112,7 @@
             </div>
           </form>
           <hr>
-          
+
           <h4 class="d-inline">{{'DS_RECORDS'|translate}}</h4>
           <form [formGroup]="digestForm" class="form-inline digests">
             <div formArrayName="itemRows">

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -30,8 +30,8 @@ export class FormComponent implements OnInit, OnChanges {
   };
   private digestFormConfig = {
     keytag: [''],
-    algorithm: [''],
-    digtype: [''],
+    algorithm: [-1],
+    digtype: [-1],
     digest: ['']
   };
   public NSForm: FormGroup;


### PR DESCRIPTION
## Purpose

Display placeholder on DS select

## Context

Fix #226

## Changes

Use -1 as default instead of `''`

## How to test this PR

Open the advanced option menu and check that all selects have a placeholder.
![Screenshot_2021-06-16 Zonemaster](https://user-images.githubusercontent.com/19394895/122216019-355e4780-ceac-11eb-8f8e-592ed66ac303.png)

