### PR TITLE
fix critical messages count

### DIFF
--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -89,7 +89,8 @@
       <li class="nav-item ml-1">
         <a  placement="top" ngbTooltip="Critical - means a very serious error." class="nav-link" [ngClass]="{'active critical text-white': result_filter.critical}"
            (click)="togglePillFilter('critical')"
-           [(ngModel)]="result_filter.critical" ngDefaultControl>Critical <span class="badge badge-pill badge-secondary">0</span></a>
+           [(ngModel)]="result_filter.critical" ngDefaultControl>
+          Critical <span class="badge badge-pill badge-secondary">{{level_items['critical'].length}}</span></a>
       </li>
       <li class="search ml-1">
         <div class="input-group">


### PR DESCRIPTION
## Purpose

Fix the critical message count in the result component.

## Context

This counter was never displayed.

## How to test this PR

Try testing a non existing domain, the backend should return 2 critical messages, check that the badge next to "Critical" really display "2".

![Screenshot 2021-06-30 at 15-56-37 Zonemaster](https://user-images.githubusercontent.com/19394895/123973184-d6c0bf80-d9bb-11eb-97e5-434f44bbb244.png)

