### PR TITLE
don't collapse expended modules when language changes

### DIFF
--- a/e2e/FR22.e2e-spec.ts
+++ b/e2e/FR22.e2e-spec.ts
@@ -18,11 +18,11 @@ describe('Zonemaster test FR22 - [Provide the possibility to see more informatio
     await element(by.css('#domain_check_name')).sendKeys('afNiC.Fr');
     await element(by.css('div button.launch')).click();
 
-    await browser.wait(() => element(by.css('#collapsed_module_1')).isPresent(), 120 * 1000);
+    await browser.wait(() => element(by.css('#collapsed_module_BASIC')).isPresent(), 120 * 1000);
 
-    await expect(element(by.css('#collapsed_module_1')).getText()).toEqual('BASIC');
-    await expect(element.all(by.css('#collapsed_module_1 > tr.show')).count()).toBe(0);
-    await element(by.css('#collapsed_module_1 > tr:nth-child(1)')).click();
-    await expect(element.all(by.css('#collapsed_module_1 > tr.show')).count()).toEqual(14);
+    await expect(element(by.css('#collapsed_module_BASIC')).getText()).toEqual('BASIC');
+    await expect(element.all(by.css('#collapsed_module_BASIC > tr.show')).count()).toBe(0);
+    await element(by.css('#collapsed_module_BASIC > tr:nth-child(1)')).click();
+    await expect(element.all(by.css('#collapsed_module_BASIC > tr.show')).count()).toEqual(14);
   });
 });

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -166,17 +166,17 @@
 
 
 <ng-template #resutlCollapsedTemplate>
-  <tbody *ngFor="let moduleKey of modulesKeys | filter : result_filter['search']:true:module_items | filterByCategories:result_filter:searchQueryLength:'level':true:module_items; let a = index" id="collapsed_module_{{a}}">
-  <tr (click)="isCollapsed[a] = !isCollapsed[a]"
-      [attr.aria-expanded]="!isCollapsed[a]" aria-controls="collapseExample" class="expand result {{modules[moduleKey]}}" >
+  <tbody *ngFor="let moduleKey of modulesKeys | filter : result_filter['search']:true:module_items | filterByCategories:result_filter:searchQueryLength:'level':true:module_items" id="collapsed_module_{{moduleKey}}">
+  <tr (click)="isCollapsed[moduleKey] = !isCollapsed[moduleKey]"
+      [attr.aria-expanded]="!isCollapsed[moduleKey]" aria-controls="collapseExample" class="expand result {{modules[moduleKey]}}" >
     <th scope="row" >
-      <a placement="top" ngbTooltip="{{(isCollapsed[a] ? 'Expand': 'Collapse')}}">
-        <i class="fa" [ngClass]="{'fa-plus': isCollapsed[a],'fa-minus': !isCollapsed[a]}" aria-hidden="true"></i>
+      <a placement="top" ngbTooltip="{{(isCollapsed[moduleKey] ? 'Expand': 'Collapse')}}">
+        <i class="fa" [ngClass]="{'fa-plus': isCollapsed[moduleKey],'fa-minus': !isCollapsed[moduleKey]}" aria-hidden="true"></i>
       </a>
     </th>
     <td colspan="3">{{moduleKey}}</td>
   </tr>
-  <tr [ngbCollapse]="isCollapsed[a]" *ngFor="let item of module_items[moduleKey] | filter : result_filter['search'] | filterByCategories : result_filter:searchQueryLength:'level'; let i = index" class="result {{item.level}}">
+  <tr [ngbCollapse]="isCollapsed[moduleKey]" *ngFor="let item of module_items[moduleKey] | filter : result_filter['search'] | filterByCategories : result_filter:searchQueryLength:'level'; let i = index" class="result {{item.level}}">
     <th scope="row">{{i}}</th>
     <td>{{item.module|translate}}</td>
     <td>{{item.level}}</td>

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -75,7 +75,7 @@ export class ResultComponent implements OnInit, OnChanges {
         if (notFirst) {
           notFirst = !notFirst;
         } else {
-          this.displayResult(this.resultID, event.lang);
+          this.displayResult(this.resultID, event.lang, false);
         }
         this.language = event.lang;
       });
@@ -85,7 +85,7 @@ export class ResultComponent implements OnInit, OnChanges {
   ngOnChanges() {
     this.displayResult(this.resultID, this.translateService.currentLang);
     this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
-      this.displayResult(this.resultID, event.lang);
+      this.displayResult(this.resultID, event.lang, false);
       this.language = event.lang;
     });
   }
@@ -97,9 +97,8 @@ export class ResultComponent implements OnInit, OnChanges {
       console.log(reason);
     });
   }
-$
 
-   private displayResult(domainCheckId: string, language: string) {
+   private displayResult(domainCheckId: string, language: string, resetCollapsed = true) {
      this.dnsCheckService.getTestResults({id: domainCheckId, language}).then(data => {
       // TODO clean
 
@@ -117,10 +116,12 @@ $
       this.setModulesColors(data['results']);
 
       this.modulesKeys = Object.keys(this.modules);
-      
-      for (let i = 0; i < this.modulesKeys.length; i++) {
-        this.isCollapsed[i] = true;
-        this.module_items[this.modulesKeys[i]] = [];
+
+      for (let moduleName of this.modulesKeys) {
+        if (resetCollapsed || !(moduleName in this.isCollapsed)) {
+          this.isCollapsed[moduleName] = true;
+        }
+        this.module_items[moduleName] = [];
       }
 
       for (const item of data['results']) {
@@ -154,7 +155,7 @@ $
       this.translateService.get('History information request is in progress').subscribe((res: string) => {
         this.alertService.info(res);
       });
-      
+
       this.dnsCheckService.getTestHistory(this.historyQuery).then(data => {
         this.history = data as any[];
         if (this.history.length === 0) {


### PR DESCRIPTION
## Purpose

When someone changes the language once the results are displayed, if one of the module is expended then is will be collapsed.

## Changes

This PR changes the behaviour of the result component to not re-collapse modules if the language has changed. 

When the result id changes the behaviour remains the same as before.

## How to test this PR

* Open a test results (ex. http://localhost:4200/result/df0aa98ff4e53b99 if your dev environment point to zonemaster.net)
* Expend a module
* Change the language
* If the module remains expended, it is working as expected
* Now try to change the result id by displaying another test from the history
* If all modules are now collapsed, it is working as expected
