### PR TITLE
store language in local storage

### DIFF
--- a/e2e/FR08.e2e-spec.ts
+++ b/e2e/FR08.e2e-spec.ts
@@ -4,7 +4,8 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR08 - [Presence of a default fallback language - English]', () => {
   const utils = new Utils();
-  beforeAll(() => {
+  beforeAll(async () => {
+    await utils.clearBrowserCache();
     utils.goToHome();
   });
 

--- a/e2e/FR10.e2e-spec.ts
+++ b/e2e/FR10.e2e-spec.ts
@@ -4,7 +4,8 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR10 - [On launching the URL opens with a default simple view]', () => {
   const utils = new Utils();
-  beforeAll(() => {
+  beforeAll(async () => {
+    await utils.clearBrowserCache();
     utils.goToHome();
   });
   it('should have [Domain name] label visible', () => {

--- a/e2e/FR21.e2e-spec.ts
+++ b/e2e/FR21.e2e-spec.ts
@@ -8,11 +8,11 @@ import { Utils } from './utils/app.utils';
 describe('Zonemaster test FR21 - [Able to provide a summarized result of the test being run ' +
   '(possibility in different colours for error, warning, success etc.)]', () => {
   const utils = new Utils();
-  beforeAll(() => {
+  beforeAll(async () => {
     utils.goToHome();
-    utils.setLang('en');
+    await utils.setLang('en');
     utils.activeOptions();
-    utils.clearBrowserCache();
+    await utils.clearBrowserCache();
   });
 
   it('should display summary',  async() => {
@@ -40,7 +40,7 @@ describe('Zonemaster test FR21 - [Able to provide a summarized result of the tes
     await expect(element.all(by.css('.nav.nav-pills.vertical-align.filter > li > a > span.badge')).get(3).getText()).toBe('0');
     await expect(element.all(by.css('.nav.nav-pills.vertical-align.filter > li > a > span.badge')).get(4).getText()).toBe('0');
     await expect(element.all(by.css('.nav.nav-pills.vertical-align.filter > li > a > span.badge')).get(5).getText()).toBe('0');
-  });  
+  });
 */
 
   it('should display summary with good colors',  async() => {
@@ -52,8 +52,3 @@ describe('Zonemaster test FR21 - [Able to provide a summarized result of the tes
     expect(await browser.imageComparison.checkFullPageScreen('result')).toBeLessThan(5);
   });
 });
-
-
-
-
-

--- a/e2e/utils/app.utils.ts
+++ b/e2e/utils/app.utils.ts
@@ -23,9 +23,11 @@ export class Utils {
   }
 
   clearBrowserCache() {
-    browser.executeScript('window.localStorage.clear();');
-    browser.executeScript('window.sessionStorage.clear();');
-    browser.driver.manage().deleteAllCookies();
+    return Promise.all([
+      browser.executeScript('window.localStorage.clear();'),
+      browser.executeScript('window.sessionStorage.clear();'),
+      browser.driver.manage().deleteAllCookies(),
+    ])
   }
 
 }

--- a/src/app/components/navigation/navigation.component.ts
+++ b/src/app/components/navigation/navigation.component.ts
@@ -17,7 +17,7 @@ export class NavigationComponent implements OnInit {
 
   constructor(private translateService: TranslateService, zone: NgZone) {
     this.translateService.setDefaultLang(this.lang_default);
-    this.lang = this.translateService.getBrowserLang();
+    this.lang = localStorage.getItem('lang') || this.translateService.getBrowserLang();
     if (this.isValidLanguage(this.lang)) {
       this.setLanguage(this.lang);
     } else {
@@ -50,6 +50,7 @@ export class NavigationComponent implements OnInit {
   public setLanguage(lang: string) {
     this.translateService.use(lang).subscribe(() => {
       this.lang = lang;
+      localStorage.setItem('lang', this.lang);
     });
   }
 


### PR DESCRIPTION
## Purpose

Remember the language so someone who change it does not have to set it each it they use zonemaster.

## Context

Addresses #229

## Changes

Stores the language in local storage and retrieves it at load time. If no language is found is storage defaults on the browser language.

## How to test this PR

* Change the language
* Reload
* Check that the selected language is the same
