### PR TITLE
[proposal] Removing background colors in results array and buttons

### DIFF
--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -85,6 +85,19 @@
   transition: all 300ms ease-in-out;
 }
 
+
+.thead-dark tr th:first-child {
+  width: 40px;
+}
+
+.thead-dark tr th:nth-child(2) {
+  width: 15%;
+}
+
+.thead-dark tr th:nth-child(3) {
+  width: 12%;
+}
+
 .active.info, .result.INFO {
   background-color: #007bff;
 }

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -129,8 +129,16 @@ tbody[id^=collapsed_module] tr:first-child th::before {
     position: absolute;
     width: 7px;
     height: 100%;
-    right: 0;
+    left: 0;
     top: 0;
+}
+.result.collapse.INFO:not(.expand) th:first-of-type::after,
+.result.collapse.NOTICE:not(.expand) th:first-of-type::after,
+.result.collapse.WARNING:not(.expand) th:first-of-type::after,
+.result.collapse.ERROR:not(.expand) th:first-of-type::after,
+.result.collapse.CRITICAL:not(.expand) th:first-of-type::after {
+    right: 0;
+    left: auto;
 }
 
 .active.info,

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -99,19 +99,19 @@
 }
 
 .active.info {
-  background-color: #007bff;
+  background-color: #66ad54;
 }
 .active.notice {
-  background-color: #fff638;
+  background-color: #007bff;
 }
 .active.warning {
   background-color: #ff9019;
 }
 .active.error {
-  background-color: #dc3545;
+  background-color: #ec3545;
 }
 .active.critical {
-  background-color: #dc3545;
+    background-color: #ec3545;
 }
 
 .export, .share, .settings {

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -98,21 +98,67 @@
   width: 12%;
 }
 
-.active.info {
+tr.collapse > th {
+    background-color: #fff;
+    border-top: 0 !important;
+}
+
+.result.INFO:not(.expand) th:first-of-type,
+.result.NOTICE:not(.expand) th:first-of-type,
+.result.WARNING:not(.expand) th:first-of-type,
+.result.ERROR:not(.expand) th:first-of-type,
+.result.CRITICAL:not(.expand) th:first-of-type,
+tbody tr:first-child th {
+    position: relative;
+}
+
+tbody[id^=collapsed_module] tr:first-child th::before {
+    content: "";
+    position: absolute;
+    width: 7px;
+    height: 100%;
+    left: 0;
+    top: 0;
+}
+.result.INFO:not(.expand) th::after,
+.result.NOTICE:not(.expand) th::after,
+.result.WARNING:not(.expand) th::after,
+.result.ERROR:not(.expand) th::after,
+.result.CRITICAL:not(.expand) th::after {
+    content: "";
+    position: absolute;
+    width: 7px;
+    height: 100%;
+    right: 0;
+    top: 0;
+}
+
+.active.info,
+.result.INFO:not(.expand) th::after,
+tbody[id^=collapsed_module] tr.INFO th::before {
   background-color: #66ad54;
 }
-.active.notice {
+.active.notice,
+.result.NOTICE:not(.expand) th::after,
+tbody[id^=collapsed_module] tr.NOTICE th::before {
   background-color: #007bff;
 }
-.active.warning {
+.active.warning,
+.result.WARNING:not(.expand) th::after,
+tbody[id^=collapsed_module] tr.WARNING th::before {
   background-color: #ff9019;
 }
-.active.error {
+.active.error,
+.result.ERROR:not(.expand) th::after,
+tbody[id^=collapsed_module] tr.ERROR th::before {
   background-color: #ec3545;
 }
-.active.critical {
-    background-color: #ec3545;
+.active.critical,
+.result.CRITICAL:not(.expand) th::after,
+tbody[id^=collapsed_module] tr.CRITICAL th::before {
+  background-color: #ec3545;
 }
+
 
 .export, .share, .settings {
   margin-left: 5px;

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -98,19 +98,19 @@
   width: 12%;
 }
 
-.active.info, .result.INFO {
+.active.info {
   background-color: #007bff;
 }
-.active.notice, .result.NOTICE {
+.active.notice {
   background-color: #fff638;
 }
-.active.warning, .result.WARNING {
+.active.warning {
   background-color: #ff9019;
 }
-.active.error, .result.ERROR {
+.active.error {
   background-color: #dc3545;
 }
-.active.critical, .result.CRITICAL {
+.active.critical {
   background-color: #dc3545;
 }
 

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -167,6 +167,24 @@ tbody[id^=collapsed_module] tr.CRITICAL th::before {
   background-color: #ec3545;
 }
 
+.result td:nth-child(3) {
+    font-weight: 700;
+}
+.result.INFO td:nth-child(3) {
+    color: #66ad54;
+}
+.result.NOTICE td:nth-child(3) {
+    color: #007bff;
+}
+.result.WARNING td:nth-child(3) {
+    color: #ff9019;
+}
+.result.ERROR td:nth-child(3) {
+    color: #ec3545;
+}
+.result.CRITICAL td:nth-child(3) {
+    color: #ec3545;
+}
 
 .export, .share, .settings {
   margin-left: 5px;

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -98,6 +98,10 @@
   width: 12%;
 }
 
+.table-striped tbody tr.collapse {
+    background-color: inherit;
+}
+
 tr.collapse > th {
     background-color: #fff;
     border-top: 0 !important;

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -29,6 +29,10 @@
   flex: 1
 }
 
+.nav-link.active.all {
+    background-color: #919191;
+}
+
 .nav-link {
   cursor: pointer;
 }

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -52,7 +52,7 @@
 
     <ul class="nav nav-pills vertical-align filter">
       <li class="nav-item ml-1">
-        <a placement="top" ngbTooltip="Display all results" class="nav-link" [ngClass]="{'active text-white': result_filter.all}"
+        <a placement="top" ngbTooltip="Display all results" class="nav-link" [ngClass]="{'active all text-white': result_filter.all}"
            (click)="togglePillFilter('all')"
            [(ngModel)]="result_filter.all" ngDefaultControl>
           All <span class="badge badge-pill badge-secondary">{{result.length}}</span></a>

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -9,15 +9,15 @@
     </div>
     <div class="col-md-6">
       <div class="pull-right actions_btn" >
-        <a class="btn btn-warning history" (click)="getHistory()">
+        <a class="btn btn-secondary history" (click)="getHistory()">
           <i class="fa fa-history text-white" aria-hidden="true"></i>
           <span class="text-white">{{'History'|translate}}</span>
         </a>
-        <a class="btn btn-info export" (click)="openModal(exportModal)">
+        <a class="btn btn-secondary export" (click)="openModal(exportModal)">
           <i class="fa fa-cloud-download text-white"></i>
           <span class="text-white">{{'Export'|translate}}</span>
         </a>
-        <a class="btn btn-success share" (click)="openModal(shareLinkModal)">
+        <a class="btn btn-secondary share" (click)="openModal(shareLinkModal)">
           <i class="fa fa-share text-white"></i>
           <span class="text-white">{{'Share'|translate}}</span>
         </a>

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -108,7 +108,7 @@
     <table class="table table-striped">
       <thead class="thead-dark">
       <tr>
-        <th scope="col">#</th>
+        <th scope="col"></th>
         <th scope="col">{{ 'Module' | translate }}</th>
         <th scope="col">{{ 'Level' | translate }}</th>
         <th scope="col">{{ 'Message' | translate }}</th>
@@ -116,7 +116,7 @@
       </thead>
       <tbody *ngIf="!resutlCollapsed;else resutlCollapsedTemplate">
       <tr *ngFor="let item of result | filter : result_filter['search'] | filterByCategories : result_filter:searchQueryLength:'level'; let i = index" class="result {{item.level}}">
-        <th scope="row">{{i}}</th>
+        <th scope="row"></th>
         <td>{{item.module|translate}}</td>
         <td>{{item.level}}</td>
         <td>{{item.message|translate}}</td>
@@ -178,7 +178,7 @@
     <td colspan="3">{{moduleKey}}</td>
   </tr>
   <tr [ngbCollapse]="isCollapsed[moduleKey]" *ngFor="let item of module_items[moduleKey] | filter : result_filter['search'] | filterByCategories : result_filter:searchQueryLength:'level'; let i = index" class="result {{item.level}}">
-    <th scope="row">{{i}}</th>
+    <th scope="row"></th>
     <td>{{item.module|translate}}</td>
     <td>{{item.level}}</td>
     <td>{{item.message|translate}}</td>


### PR DESCRIPTION
## Purpose

This is a suggestion to have less colors on the UI. This is also about sharing the code I wrote for https://github.com/zonemaster/zonemaster-gui/issues/153#issuecomment-811107482

## Context

Try to address #150, #153

## Changes

* Removes the line number in the result array

* Set new column width

* Defines new colors

| Level | color |
| --- | --- |
| INFO | `#66ad54` |
| NOTICE | `#007bff` |
| WARNING | `#ff9019` |
| ERROR | `#ec3545` |
| CRITICAL | `#ec3545` |

### Collapsed table

![zm-gui1](https://user-images.githubusercontent.com/70589067/124500573-4d94f880-ddc0-11eb-8a7c-d84e691c0d85.png)

### Filters and buttons

![zm-gui2](https://user-images.githubusercontent.com/70589067/124500576-4d94f880-ddc0-11eb-9ea0-915a61d080e6.png)

### Expand some modules

![zm-gui3](https://user-images.githubusercontent.com/70589067/124500577-4e2d8f00-ddc0-11eb-8b03-a57a88eab434.png)

### Do not group by modules

![zm-gui4](https://user-images.githubusercontent.com/70589067/124500578-4e2d8f00-ddc0-11eb-89d2-9b75bcd2e5ee.png)

## How to test this PR

Only affecting CSS, the testing is made visually.
