### PR TITLE
Remove the test number in the results

### DIFF
--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -4,7 +4,7 @@
 <div class="result container" #resultView>
   <div class="row">
     <div class="col-md-6">
-      <h2>{{'Test #'|translate}}{{ test.id }}<small> - {{form.domain}}</small></h2>
+      <h2>{{form.domain}}</h2>
       <i>{{ test.creation_time | amFromUtc | date:'yyyy-MM-dd HH:mm zzzz' }}</i>
     </div>
     <div class="col-md-6">


### PR DESCRIPTION
## Purpose

Currently the result page highlight the test number more than the domain name. This looks like an odd choice as we don't use this number anywhere. This PR removes the test number and highlights the domain instead.

This test id also leaks the number of tests in database.

## Context

n/a

## Changes

* Removes the test number
* Highlights the domain name

### Before

![zm-gui-header-1](https://user-images.githubusercontent.com/70589067/124151296-b0218800-da92-11eb-86c1-d234e40ec91b.png)

### After

![zm-gui-header-2](https://user-images.githubusercontent.com/70589067/124151298-b0ba1e80-da92-11eb-9cbd-d674d233d896.png)


## How to test this PR

Verify that only the domain name is displayed.
