### PR TITLE
Avoid using modal window

### DIFF
--- a/e2e/FR25.e2e-spec.ts
+++ b/e2e/FR25.e2e-spec.ts
@@ -13,21 +13,21 @@ describe('Zonemaster test FR25 - [Should be able to export the result in multipl
   });
 
   it('should have an export button',  async() => {
-    await browser.wait(() => element(by.css('a.btn.export')).isPresent(), 120 * 1000);
+    await browser.wait(() => element(by.css('button.btn.export')).isPresent(), 120 * 1000);
 
-    await expect(element(by.css('a.btn.export')).getText()).toEqual('Export');
+    await expect(element(by.css('button.btn.export')).getText()).toEqual('Export');
   });
 
   it('should open a modal and contains for export possibilities (HTML, CSV, HTML, TEXT)', async() => {
-    await element(by.css('a.btn.export')).click();
-    const modal = element(by.css('.modal.fade.show'));
-    await browser.wait(() => modal.isDisplayed(), 10 * 1000);
+    await element(by.css('button.btn.export')).click();
+    const box = element(by.css('button.btn.export + div.show'));
+    await browser.wait(() => box.isDisplayed(), 10 * 1000);
 
-    await expect(element.all(by.css('.modal-body > button.btn')).count()).toEqual(4);
-    await expect(element.all(by.css('.modal-body > button.btn')).get(0).getText()).toEqual('JSON');
-    await expect(element.all(by.css('.modal-body > button.btn')).get(1).getText()).toEqual('CSV');
-    await expect(element.all(by.css('.modal-body > button.btn')).get(2).getText()).toEqual('HTML');
-    await expect(element.all(by.css('.modal-body > button.btn')).get(3).getText()).toEqual('TEXT');
+    await expect(element.all(by.css('button.btn.export + div.show button.btn')).count()).toEqual(4);
+    await expect(element.all(by.css('button.btn.export + div.show button.btn')).get(0).getText()).toEqual('JSON');
+    await expect(element.all(by.css('button.btn.export + div.show button.btn')).get(1).getText()).toEqual('CSV');
+    await expect(element.all(by.css('button.btn.export + div.show button.btn')).get(2).getText()).toEqual('HTML');
+    await expect(element.all(by.css('button.btn.export + div.show button.btn')).get(3).getText()).toEqual('TEXT');
   });
 });
 

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -47,9 +47,16 @@ button.share + .dropdown-menu .dropdown-body {
     display: flex;
 }
 
-.dropdown-body > div.btn-clipboard:hover {
+button.btn-clipboard:hover {
     border: 1px solid #cdc7c2;
 }
+button.btn-clipboard > i.fa-check {
+    color: #66ad54;
+}
+button.btn-clipboard > i.fa-remove {
+    color: #ec3545;
+}
+
 
 .ipvX {
   position: absolute;

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -44,6 +44,11 @@
 }
 button.share + .dropdown-menu .dropdown-body {
     min-width: 420px;
+    display: flex;
+}
+
+.dropdown-body > div.btn-clipboard:hover {
+    border: 1px solid #cdc7c2;
 }
 
 .ipvX {

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -37,6 +37,15 @@
   cursor: pointer;
 }
 
+.dropdown-body {
+    position: relative;
+    padding: 1rem;
+    white-space: nowrap;
+}
+button.share + .dropdown-menu .dropdown-body {
+    min-width: 420px;
+}
+
 .ipvX {
   position: absolute;
   right:0;

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -37,9 +37,9 @@
           <div ngbDropdownMenu aria-labelledby="shareDropdownResult">
               <div class="dropdown-body">
                 <input readonly="" type="text" id="link_location" name="link_location" class="form-inline" value="{{test.location}}">
-                <div class="btn btn-clipboard">
+                <button class="btn btn-clipboard" (click)="copyLinkToClipboard(test.location)">
                     <i class="fa fa-clipboard"></i>
-                </div>
+                </button>
               </div>
           </div>
         </div>

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -13,10 +13,21 @@
           <i class="fa fa-history text-white" aria-hidden="true"></i>
           <span class="text-white">{{'History'|translate}}</span>
         </a>
-        <a class="btn btn-secondary export" (click)="openModal(exportModal)">
-          <i class="fa fa-cloud-download text-white"></i>
-          <span class="text-white">{{'Export'|translate}}</span>
-        </a>
+
+        <div ngbDropdown class="d-inline-block">
+          <button class="btn btn-secondary export" id="shareDropdownResult" ngbDropdownToggle>
+            <i class="fa fa-cloud-download text-white"></i>
+            <span class="text-white">{{'Export'|translate}}</span>
+          </button>
+          <div ngbDropdownMenu aria-labelledby="shareDropdownResult">
+              <div class="modal-body">
+                <button class="btn" (click)="exportJson()"> JSON </button>
+                <button class="btn" (click)="exportCSV()"> CSV </button>
+                <button class="btn" (click)="exportHTML()"> HTML </button>
+                <button class="btn" (click)="exportText()"> TEXT </button>
+              </div>
+          </div>
+        </div>
 
         <div ngbDropdown class="d-inline-block">
           <button class="btn btn-secondary share" id="shareDropdownResult" ngbDropdownToggle>
@@ -131,21 +142,6 @@
     </table>
   </div>
 </div>
-
-<ng-template #exportModal let-c="close" let-d="dismiss">
-  <div class="modal-header">
-    <h4 class="modal-title">{{'Export'|translate}}</h4>
-    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
-      <span aria-hidden="true">&times;</span>
-    </button>
-  </div>
-  <div class="modal-body">
-    <button class="btn" (click)="exportJson()"> JSON </button>
-    <button class="btn" (click)="exportCSV()"> CSV </button>
-    <button class="btn" (click)="exportHTML()"> HTML </button>
-    <button class="btn" (click)="exportText()"> TEXT </button>
-  </div>
-</ng-template>
 
 <ng-template #historyModal let-c="close" let-d="dismiss">
   <div class="modal-header">

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -14,7 +14,7 @@
           <span class="text-white">{{'History'|translate}}</span>
         </a>
 
-        <div ngbDropdown class="d-inline-block">
+        <div ngbDropdown placement="bottom-right" class="d-inline-block">
           <button class="btn btn-secondary export" id="shareDropdownResult" ngbDropdownToggle>
             <i class="fa fa-cloud-download text-white"></i>
             <span class="text-white">{{'Export'|translate}}</span>
@@ -29,7 +29,7 @@
           </div>
         </div>
 
-        <div ngbDropdown class="d-inline-block">
+        <div ngbDropdown placement="bottom-right" class="d-inline-block">
           <button class="btn btn-secondary share" id="shareDropdownResult" ngbDropdownToggle>
             <i class="fa fa-share text-white"></i>
             <span class="text-white">{{'Share'|translate}}</span>
@@ -44,7 +44,7 @@
           </div>
         </div>
 
-        <div ngbDropdown class="d-inline-block">
+        <div ngbDropdown placement="bottom-right" class="d-inline-block">
           <button class="btn btn-secondary settings" id="settingsDropdownResult" ngbDropdownToggle>
             <i class="fa fa-wrench text-white"></i>
             <span class="text-white">{{'Settings'|translate}}</span>

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -20,7 +20,7 @@
             <span class="text-white">{{'Export'|translate}}</span>
           </button>
           <div ngbDropdownMenu aria-labelledby="shareDropdownResult">
-              <div class="modal-body">
+              <div class="dropdown-body">
                 <button class="btn" (click)="exportJson()"> JSON </button>
                 <button class="btn" (click)="exportCSV()"> CSV </button>
                 <button class="btn" (click)="exportHTML()"> HTML </button>
@@ -35,7 +35,7 @@
             <span class="text-white">{{'Share'|translate}}</span>
           </button>
           <div ngbDropdownMenu aria-labelledby="shareDropdownResult">
-              <div class="modal-body">
+              <div class="dropdown-body">
                 <input readonly="" type="text" id="link_location" name="link_location" class="form-inline" value="{{test.location}}">
               </div>
           </div>

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -17,10 +17,18 @@
           <i class="fa fa-cloud-download text-white"></i>
           <span class="text-white">{{'Export'|translate}}</span>
         </a>
-        <a class="btn btn-secondary share" (click)="openModal(shareLinkModal)">
-          <i class="fa fa-share text-white"></i>
-          <span class="text-white">{{'Share'|translate}}</span>
-        </a>
+
+        <div ngbDropdown class="d-inline-block">
+          <button class="btn btn-secondary share" id="shareDropdownResult" ngbDropdownToggle>
+            <i class="fa fa-share text-white"></i>
+            <span class="text-white">{{'Share'|translate}}</span>
+          </button>
+          <div ngbDropdownMenu aria-labelledby="shareDropdownResult">
+              <div class="modal-body">
+                <input readonly="" type="text" id="link_location" name="link_location" class="form-inline" value="{{test.location}}">
+              </div>
+          </div>
+        </div>
 
         <div ngbDropdown class="d-inline-block">
           <button class="btn btn-secondary settings" id="settingsDropdownResult" ngbDropdownToggle>
@@ -123,18 +131,6 @@
     </table>
   </div>
 </div>
-
-<ng-template #shareLinkModal let-c="close" let-d="dismiss">
-  <div class="modal-header">
-    <h4 class="modal-title">{{'Link'|translate}}</h4>
-    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
-      <span aria-hidden="true">&times;</span>
-    </button>
-  </div>
-  <div class="modal-body">
-    <input type="text" id="link_location" name="link_location" class="form-inline" value="{{test.location}}">
-  </div>
-</ng-template>
 
 <ng-template #exportModal let-c="close" let-d="dismiss">
   <div class="modal-header">

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -37,6 +37,9 @@
           <div ngbDropdownMenu aria-labelledby="shareDropdownResult">
               <div class="dropdown-body">
                 <input readonly="" type="text" id="link_location" name="link_location" class="form-inline" value="{{test.location}}">
+                <div class="btn btn-clipboard">
+                    <i class="fa fa-clipboard"></i>
+                </div>
               </div>
           </div>
         </div>

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -303,4 +303,45 @@ export class ResultComponent implements OnInit, OnChanges {
     }
   }
 
+  // inspired from
+  // https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript#30810322
+  public copyLinkToClipboard(str) {
+    var btnClipboard = document.getElementsByClassName("btn-clipboard")[0];
+    var icon = btnClipboard.firstElementChild;
+
+    var resetIcon = function(oldIcon) {
+      setTimeout(function() {
+        icon.classList.remove(oldIcon);
+        icon.classList.add("fa-clipboard");
+      }, 2000);
+    };
+
+    var textArea = document.createElement("textarea");
+    textArea.value = str;
+
+    textArea.style.top = "0";
+    textArea.style.left = "0";
+    textArea.style.position = "fixed";
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    var res = document.execCommand('copy');
+
+    if (res === true) {
+      icon.classList.remove("fa-clipboard");
+      icon.classList.add("fa-check");
+
+      resetIcon("fa-check");
+    } else {
+      icon.classList.remove("fa-clipboard");
+      icon.classList.add("fa-remove");
+
+      resetIcon("fa-remove");
+    }
+
+    document.body.removeChild(textArea);
+  }
+
 }


### PR DESCRIPTION
## Purpose

This PR is a proposal to avoid using the modal window for the "Share" and "Export" buttons.
This also adds an icon to copy the link to the clipboard.

## Context

Addresses #238

## Changes

### Share box
![zm-gui-drop2](https://user-images.githubusercontent.com/70589067/124907065-07ba7900-dfe8-11eb-8b7c-e9cbbb0b9d46.png)

Once you click, if the URL has been copied, you get the following visual feedback:
![zm-gui-drop3](https://user-images.githubusercontent.com/70589067/124907067-07ba7900-dfe8-11eb-8ef5-de955ec0d2a1.png)

this one otherwise:
![zm-gui-drop4](https://user-images.githubusercontent.com/70589067/124907069-07ba7900-dfe8-11eb-8f74-94b56d771faa.png)

### Export box

![zm-gui-drop1](https://user-images.githubusercontent.com/70589067/124907061-0721e280-dfe8-11eb-9cfb-ae69686bbac3.png)

### Settings (right alignment as well)

![zm-gui-drop5](https://user-images.githubusercontent.com/70589067/124907072-08530f80-dfe8-11eb-9d39-0a58e002966c.png)

## How to test this PR

1. copy/paste a garbage text
2. click on the "Share" button
2. click on the "copy" icon
3. you should get a green check icon
4. paste somewhere what is in the buffer
5. you should get the link (and not the garbage text)