### PR TITLE
Serve GUI from custom base url

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -9,8 +9,9 @@ Zonemaster product, please see the [main Zonemaster Repository].
 
 The release bundle available in the Github release expects Zonemaster Web GUI
 to be served on its own domain, with the base url `/`. If you wish to serve the
-GUI on a different base url, ex. `/zonemaster/` use the instruction at the end
-of this document to compile a custom bundle.
+GUI on a different base url, e.g. `/zonemaster/` use
+[the instructions][custom base install] at the end of this document to build
+a custom bundle.
 
 
 ## Prerequisites
@@ -302,3 +303,4 @@ Make sure Zonemaster-GUI is properly installed.
 [Zonemaster::Engine installation]: https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md
 [Zonemaster::Engine]: https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
 [Zonemaster::LDNS]: https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
+[custom base install]: #serving-the-gui-and-api-from-a-custom-base-url

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -223,9 +223,21 @@ Use the procedure for installation on [Debian](#2-debian).
 ## Serving the GUI and API from a custom base url
 
 In some cases you may want to customize the application to change the base url
-from wich the GUI is served, or change the API endpoint url from the default
-`/api` to something else.
-To achieve that you will need to build the application yourself.
+from wich the GUI is served.
+
+To achieve that you will either need to change the `<base>` in the `index.html`
+or build the application yourself.
+
+### Change the base url in index.html
+
+Locate the line `<base href="/">` and replace the `href` value with the path you
+want to server the GUI from, e.g. `<base href="/zonemaster/">`. Don't forget the
+trailing `/`.
+
+**NOTE:** Don't forget to update the base after each upgrade as the file will be
+overwritten.
+
+### Building the application
 
 First make sure you have an up-to-date NodeJS/npm installation, then clone this
 repository and install the required dependencies.
@@ -236,28 +248,19 @@ repository and install the required dependencies.
 % npm i
 ```
 
-* To change Zonemaster-Backend API endpoint, update
-  `src/environments/environment.prod.ts` and change the `apiEndpoint` with the
-  location of where you are serving the API. For example:
-  ```js
-  export const environment = {
-     apiEndpoint: '/zonemaster/api',
-    ...
-    // Unchanged values not shown
-  };
-  ```
-  Then compile the application with the command `npm run build`.
+To change the base url of the GUI compile the application using
+`npm run build -- --base-href /zonemaster/`.
+Replace `/zonemaster/` with the base you want, do not forget the trailing `/`.
 
-* To change the base url of the GUI compile the application using
-  `npm run build -- --base-href /zonemaster/`.
-  Replace `/zonemaster/` with the base you want, do not forget the trailing `/`.
+The build step create a `dist` directory that contains the files to serve from
+your Web server.
 
-In both cases the build step create a `dist` directory that contains the files
-to serve from your Web server.
+### Web server configuration
 
 When serving the application from a different base, you will also need to change
 the Web server configuration by adding an `Alias` directive after the proxy ones.
-Combined with the change of the API endpoint location this gives something like:
+Combined with the change of the [API endpoint location] this gives something
+like:
 
 ```apache
 ProxyPass /zonemaster/api http://localhost:5000/
@@ -304,3 +307,4 @@ Make sure Zonemaster-GUI is properly installed.
 [Zonemaster::Engine]: https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
 [Zonemaster::LDNS]: https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
 [custom base install]: #serving-the-gui-and-api-from-a-custom-base-url
+[API endpoint location]: ../Configuration.md

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -30,9 +30,8 @@ installation].
 This instruction covers the following operating systems:
 
  1. [CentOS](#1-centos)
- 2. [Debian](#2-debian)
+ 2. [Debian](#2-debian-and-ubuntu)
  3. [FreeBSD](#3-freebsd)
- 4. [Ubuntu](#4-ubuntu)
 
 
 ### 1. CentOS
@@ -81,7 +80,7 @@ sudo firewall-cmd --add-service http --permanent
 sudo firewall-cmd --reload
 ```
 
-### 2. Debian
+### 2. Debian and Ubuntu
 
 #### Install Apache
 
@@ -215,47 +214,35 @@ file so that it points to correct IP address or server name and correct port.
 service apache24 restart
 ```
 
-### 4. Ubuntu
+## Post-installation sanity check
 
-Use the procedure for installation on [Debian](#2-debian).
+Make sure Zonemaster-GUI is properly installed.
 
+1. Point your browser at `http://localhost/` (or the address of the server where
+   you installed Zonemaster Web GUI).
+
+2. Verify that the Zonemaster Web GUI is shown with the text "Program versions" in
+   its page footer.
+
+3. Verify that when you mouse over this text the versions of the following
+   Zonemaster components are shown: Backend, Engine and GUI.
+
+## What to do next?
+
+ * For a JSON-RPC API, see the Zonemaster::Backend [JSON-RPC API] documentation.
+ * For a command line interface, follow the [Zonemaster::CLI installation] instruction.
+ * For a Perl API, see the [Zonemaster::Engine API] documentation.
+ * For Https, see [Let's Encrypt / Certbot].
 
 ## Serving the GUI and API from a custom base url
 
-In some cases you may want to customize the application to change the base url
-from wich the GUI is served.
-
-To achieve that you will either need to change the `<base>` in the `index.html`
-or build the application yourself.
-
-### Change the base url in index.html
+In some cases you may want to customize the application to change the base URL
+from wich the GUI is served. To achieve that you will need to change the
+`<base>` in the `index.html`.
 
 Locate the line `<base href="/">` and replace the `href` value with the path you
 want to server the GUI from, e.g. `<base href="/zonemaster/">`. Don't forget the
 trailing `/`.
-
-**NOTE:** Don't forget to update the base after each upgrade as the file will be
-overwritten.
-
-### Building the application
-
-First make sure you have an up-to-date NodeJS/npm installation, then clone this
-repository and install the required dependencies.
-
-```sh
-% git clone https://github.com/zonemaster/zonemaster-gui
-% cd zonemaster-gui
-% npm i
-```
-
-To change the base url of the GUI compile the application using
-`npm run build -- --base-href /zonemaster/`.
-Replace `/zonemaster/` with the base you want, do not forget the trailing `/`.
-
-The build step create a `dist` directory that contains the files to serve from
-your Web server.
-
-### Web server configuration
 
 When serving the application from a different base, you will also need to change
 the Web server configuration by adding an `Alias` directive after the proxy ones.
@@ -270,27 +257,8 @@ ProxyPreserveHost On
 Alias "/zonemaster" "/var/www/html/zonemaster-web-gui/dist"
 ```
 
-## Post-installation sanity check
-
-Make sure Zonemaster-GUI is properly installed.
-
-1. Point your browser at `http://localhost/` (or the address of the server where
-   you installed Zonemaster Web GUI).
-
-2. Verify that the Zonemaster Web GUI is shown with the text "Program versions" in
-   its page footer.
-
-3. Verify that when you mouse over this text the versions of the following
-   Zonemaster components are shown: Backend, Engine and GUI.
-
-
-
-## What to do next?
-
- * For a JSON-RPC API, see the Zonemaster::Backend [JSON-RPC API] documentation.
- * For a command line interface, follow the [Zonemaster::CLI installation] instruction.
- * For a Perl API, see the [Zonemaster::Engine API] documentation.
- * For Https, see [Let's Encrypt / Certbot].
+**NOTE:** Don't forget to apply thoses changes after each updates as the files
+will be overwritten.
 
 -------
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -238,8 +238,9 @@ from wich the GUI is served.
    e.g. `<base href="/zonemaster/">`. Don't forget the trailing `/`.
 
 2. When serving the application from a different base, you will also need to
-   change the Web server configuration by adding an `Alias` directive after the
-   proxy ones.
+   change the Web server configuration in `zonemaster.conf` (location is found
+   in the installation instructions above) by updating `ProxyPass` and
+  `ProxyPassReverse`, and adding `Alias` as in the following example:
 
    ```apache
    ProxyPass /zonemaster/api http://localhost:5000/
@@ -248,13 +249,23 @@ from wich the GUI is served.
 
    Alias "/zonemaster" "/var/www/html/zonemaster-web-gui/dist"
    ```
+3. Update or create `app.config.json` (
+   `/var/www/html/zonemaster-web-gui/dist/assets/app.config.json` in a default
+   installation) by setting `apiEndpoint` to `/zonemaster/api` as below. See
+   [Configuration.md] and the example configuration `app.config.sample.json`.
 
-3. Update `apiEndpoint` in `assets/app.config.json` (possibly creating it) and
-   set it `/zonemaster/api`. See Configuration.md and the example configuration
-   `app.config.sample.json`.
+   ```json
+   {
+      "apiEndpoint": "/zonemaster/api"
+   }
+   ```
+
+4. Reload Apache.
+5. Point you browser to the new base URL.
+
 
 **NOTE:** Don't forget to apply the changes to the `index.html` and Web
-server configurartion as thoses files will be overwritten.
+server configurartion after each updates as thoses files will be overwritten.
 
 -------
 
@@ -271,4 +282,4 @@ server configurartion as thoses files will be overwritten.
 [Zonemaster::Engine]: https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
 [Zonemaster::LDNS]: https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
 [custom base install]: #serving-the-gui-and-api-from-a-custom-base-url
-[API endpoint location]: Configuration.md
+[Configuration.md]: Configuration.md

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -307,4 +307,4 @@ Make sure Zonemaster-GUI is properly installed.
 [Zonemaster::Engine]: https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
 [Zonemaster::LDNS]: https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
 [custom base install]: #serving-the-gui-and-api-from-a-custom-base-url
-[API endpoint location]: ../Configuration.md
+[API endpoint location]: Configuration.md

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -7,13 +7,6 @@ post-install sanity checking for Zonemaster Web GUI. The final section wraps up
 with a few pointer to other interfaces to Zonemaster. For an overview of the
 Zonemaster product, please see the [main Zonemaster Repository].
 
-The release bundle available in the Github release expects Zonemaster Web GUI
-to be served on its own domain, with the base url `/`. If you wish to serve the
-GUI on a different base url, e.g. `/zonemaster/` use
-[the instructions][custom base install] at the end of this document to build
-a custom bundle.
-
-
 ## Prerequisites
 
 Before installing Zonemaster Web GUI, you should [install Zonemaster::Engine][
@@ -237,28 +230,31 @@ Make sure Zonemaster-GUI is properly installed.
 ## Serving the GUI and API from a custom base url
 
 In some cases you may want to customize the application to change the base URL
-from wich the GUI is served. To achieve that you will need to change the
-`<base>` in the `index.html`.
+from wich the GUI is served.
 
-Locate the line `<base href="/">` and replace the `href` value with the path you
-want to server the GUI from, e.g. `<base href="/zonemaster/">`. Don't forget the
-trailing `/`.
+1. In the `index.html` file, (`/var/www/html/zonemaster-web-gui/dist/index.html`
+   if you followed this installation guide), locate the line `<base href="/">`
+   and replace the `href` value with the path you want to server the GUI from,
+   e.g. `<base href="/zonemaster/">`. Don't forget the trailing `/`.
 
-When serving the application from a different base, you will also need to change
-the Web server configuration by adding an `Alias` directive after the proxy ones.
-Combined with the change of the [API endpoint location] this gives something
-like:
+2. When serving the application from a different base, you will also need to
+   change the Web server configuration by adding an `Alias` directive after the
+   proxy ones.
 
-```apache
-ProxyPass /zonemaster/api http://localhost:5000/
-ProxyPassReverse /zonemaster/api http://localhost:5000/
-ProxyPreserveHost On
+   ```apache
+   ProxyPass /zonemaster/api http://localhost:5000/
+   ProxyPassReverse /zonemaster/api http://localhost:5000/
+   ProxyPreserveHost On
 
-Alias "/zonemaster" "/var/www/html/zonemaster-web-gui/dist"
-```
+   Alias "/zonemaster" "/var/www/html/zonemaster-web-gui/dist"
+   ```
 
-**NOTE:** Don't forget to apply thoses changes after each updates as the files
-will be overwritten.
+3. Update `apiEndpoint` in `assets/app.config.json` (possibly creating it) and
+   set it `/zonemaster/api`. See Configuration.md and the example configuration
+   `app.config.sample.json`.
+
+**NOTE:** Don't forget to apply the changes to the `index.html` and Web
+server configurartion as thoses files will be overwritten.
 
 -------
 

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -4,11 +4,10 @@
   RewriteBase /
 
 # If an existing asset or directory is requested go to it as it is
-  RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]
-  RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d
+  RewriteCond %{REQUEST_FILENAME} -f [OR]
+  RewriteCond %{REQUEST_FILENAME} -d
   RewriteRule ^ - [L]
 
 # If the requested resource doesn't exist, use index.html
   RewriteRule ^ /index.html
 </IfModule>
-

--- a/src/app/components/domain/domain.component.ts
+++ b/src/app/components/domain/domain.component.ts
@@ -83,7 +83,7 @@ export class DomainComponent implements OnInit {
             self.showProgressBar = false;
             self.domain_check_progression = 5;
             self.toggleFinished = !self.toggleFinished;
-            this.location.go(this.location.prepareExternalUrl(`result/${this.resultID}`));
+            this.location.go(`/result/${this.resultID}`);
           }
         });
       }, this.intervalTime);

--- a/src/app/components/faq/faq.component.ts
+++ b/src/app/components/faq/faq.component.ts
@@ -21,7 +21,7 @@ export class FaqComponent implements OnInit, OnDestroy, AfterViewChecked {
               private translateService: TranslateService,
               private route: ActivatedRoute) {
     this.langChangeSubscription = this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
-      this.url = `/assets/faqs/gui-faq-${event.lang}.html`;
+      this.url = `assets/faqs/gui-faq-${event.lang}.html`;
       this._http.get(this.url, {responseType: 'text'})
         .subscribe(data => {
           this.faqTemplate = data;
@@ -30,7 +30,7 @@ export class FaqComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   ngOnInit() {
-    this.url = `/assets/faqs/gui-faq-${this.translateService.currentLang}.html`;
+    this.url = `assets/faqs/gui-faq-${this.translateService.currentLang}.html`;
     this._http.get(this.url, {responseType: 'text'})
       .subscribe(data => {
         this.faqTemplate = data;

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -6,6 +6,7 @@ import { saveAs } from 'file-saver';
 import {DnsCheckService} from '../../services/dns-check.service';
 import {AlertService} from '../../services/alert.service';
 import { Subscription } from 'rxjs';
+import {Location} from '@angular/common';
 
 @Component({
   selector: 'app-result',
@@ -59,7 +60,8 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
               private modalService: NgbModal,
               private alertService: AlertService,
               public translateService: TranslateService,
-              private dnsCheckService: DnsCheckService) {
+              private dnsCheckService: DnsCheckService,
+              private location: Location) {
      this.directAccess = (this.activatedRoute.snapshot.data[0] === undefined) ? false :
        this.activatedRoute.snapshot.data[0]['directAccess'];
   }
@@ -109,7 +111,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
       this.test = {
         id: data['id'],
         creation_time: data['creation_time'],
-        location: `${document.location.origin}/result/${domainCheckId}`
+        location: document.location.origin + this.location.prepareExternalUrl(`/result/${domainCheckId}`)
       };
 
       this.historyQuery = data['params'];


### PR DESCRIPTION
## Purpose

Make the GUI capable of being served from a custom base URL.

## Context

Addresses #250 

## Changes

* Fixes some dynamically built URLS.
* Add documentation for a custom installation

## How to test this PR

* Change the API endpoint to be `/zonemaster/api` in the prod environment file
* Build the app with `npm run build -- --base-href "/zonemaster/"`
* Serve the statics file using the following configuration (apache)
  ```apache
  <VirtualHost *:80>
    DocumentRoot /path/to/zonemaster-gui/dist
    DirectoryIndex index.html
    ServerAdmin example@example.net
    ServerName localhost
  
    <Directory "/path/to/zonemaster-gui/dist">
      Options Indexes MultiViews FollowSymlinks Includes
      AllowOverride All
      Require all granted
    </Directory>
  
    ProxyPass /zonemaster/api http://localhost:5000/
    ProxyPassReverse /zonemaster/api http://localhost:5000/
    ProxyPreserveHost On
    Alias "/zonemaster" "/path/to/zonemaster-gui/dist"
  
  </VirtualHost>
  ```
* Check that the GUI is loading and can access the API.
* Check that the FAQ pages are loading
* Check that the "share URL" is correct and working
* Repeat the steps with a normal build (default settings)