### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 install:
   - npm install
-  - node ./node_modules/.bin/webdriver-manager update --versions.chrome=90.0.4430.24
+  - node ./node_modules/.bin/webdriver-manager update --versions.chrome=$(google-chrome --version | sed 's/Google Chrome //')
 
 script:
   - xvfb-run npm run ng e2e -- --webdriver-update=false


### PR DESCRIPTION
## Purpose

Fix failing travis (see #252 and #253)

## Changes

Make the webdriver use the same version as google chrome. The issue raised by #210 has been fixed upstream so we can now upgrade the webdriver safely.

## How to test this PR

* Run the tests, if no error message regarding incompatible chrome version is shown then it works.
