### PR TITLE
Update URL to display the test hash ID

### DIFF
--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { Component, OnInit, OnChanges, Input, ElementRef, ViewChild } from '@angular/core';
 import {ActivatedRoute, Params} from '@angular/router';
 import {NgbModal, ModalDismissReasons} from '@ng-bootstrap/ng-bootstrap';
@@ -55,7 +56,8 @@ export class ResultComponent implements OnInit, OnChanges {
               private modalService: NgbModal,
               private alertService: AlertService,
               public translateService: TranslateService,
-              private dnsCheckService: DnsCheckService) {
+              private dnsCheckService: DnsCheckService,
+              private location: Location) {
      this.directAccess = (this.activatedRoute.snapshot.data[0] === undefined) ? false :
        this.activatedRoute.snapshot.data[0]['directAccess'];
   }
@@ -63,6 +65,11 @@ export class ResultComponent implements OnInit, OnChanges {
   ngOnInit() {
     this.language = this.translateService.currentLang;
     console.log(this.resultID);
+
+      if ( this.resultID ) {
+        var new_path = "/result/" + this.resultID;
+        this.location.go( new_path );
+      }
 
     // Le result ID ne passe pas par la lorsque domaine.ts change une seconde fois l'ID !!!
     if (this.directAccess) {


### PR DESCRIPTION
## Purpose

This PR updates the URL once a test is finished. The new URL directly points to the test results.

## Context

Fixes #240 

## Changes

Update the URL once a test is finished. Use the [Location service](https://angular.io/api/common/Location).

## How to test this PR

Run a test and wait for it to finish. Once its finished and that you see the results, check the browser address bar, it should contain the hash ID.
It should also be possible to copy/paste this URL into another window and get the same results.
