### PR TITLE
wait for the lang nav before clicking

### DIFF
--- a/e2e/utils/app.utils.ts
+++ b/e2e/utils/app.utils.ts
@@ -10,7 +10,8 @@ export class Utils {
   }
 
   setLang(lang) {
-    return element(by.xpath('//a[@lang="' + lang + '"]')).click()
+    return browser.wait(ExpectedConditions.presenceOf($(`.lang > div > a[lang="${lang}"]`)), 10000)
+      .then(() => element(by.xpath('//a[@lang="' + lang + '"]')).click())
       .then(() => browser.wait(ExpectedConditions.presenceOf($(`.lang > div > a.selected[lang="${lang}"]`)), 10000));
   }
 


### PR DESCRIPTION
## Purpose

Make running e2e tests more reliable.

Now that the language nav is populated dynamically from the configuration, the tests can fail as the elements to change the language do not exists at the time of the click.

## Changes

Try to wait for the languages list to be loaded.

## How to test this PR

Run the e2e tests
