### PR TITLE
Translate backend validation errors

### DIFF
--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -60,7 +60,7 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
   ngOnInit() {
     this.langChangeSubscription = this.translateService.onLangChange.subscribe((_: LangChangeEvent) => {
       if (this.newForm.touched) {
-        this.runDomainCheck(true);
+        this.runDomainCheck(false);
       }
     });
     this.generate_form();
@@ -233,7 +233,7 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
-  public runDomainCheck(submitNotValid = false) {
+  public runDomainCheck(submitValid = true) {
     this.newForm.markAllAsTouched();
     let param = this.newForm.value;
 
@@ -262,7 +262,7 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
         digest: ds.digest
       }});
 
-    if ((!submitNotValid && this.newForm.valid) || (submitNotValid && !this.newForm.valid)) {
+    if (submitValid == this.newForm.valid) {
       this.onDomainCheck.emit(param);
     }
   }

--- a/src/app/interceptors/mock.interceptor.ts
+++ b/src/app/interceptors/mock.interceptor.ts
@@ -7,8 +7,7 @@ const urls = [
     url: 'https://zonemaster.net/api',
     body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
       {
-        // 'language':'en', 'domain': 'afNiC.Fr', 'profile': 'default',
-        'domain': 'afNiC.Fr', 'profile': 'default',
+        'language':'en', 'domain': 'afNiC.Fr', 'profile': 'default',
         'nameservers': [], 'ds_info': []
       }
     },
@@ -19,8 +18,7 @@ const urls = [
     url: 'https://zonemaster.net/api',
     body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
       {
-        // 'language':'en', 'domain': 'afNiC.Fr', 'profile': 'default',
-        'domain': 'afNiC.Fr', 'profile': 'default',
+        'language':'en', 'domain': 'afNiC.Fr', 'profile': 'default',
         'nameservers': [{"ns": "ns1.nic.fr"}], 'ds_info': []
       }
     },
@@ -31,8 +29,7 @@ const urls = [
     url: 'https://zonemaster.net/api',
     body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
       {
-        // 'language':'en', 'domain': 'afNiC.Fr', 'profile': 'default',
-        'domain': 'afNiC.Fr', 'profile': 'default',
+        'language':'en', 'domain': 'afNiC.Fr', 'profile': 'default',
         'nameservers': [{"ns":"", "ip": "192.134.4.1"}], 'ds_info': []
       }
     },
@@ -56,8 +53,7 @@ const urls = [
     url: 'https://zonemaster.net/api',
     body:{'jsonrpc': '2.0', 'id': 1572277567967, 'method': 'start_domain_test', 'params':
       {
-        // 'language':'en', 'domain': 'afNiC.Fr', 'profile': 'default',
-        'domain': 'afNiC.Fr', 'profile': 'default',
+        'language':'en', 'domain': 'afNiC.Fr', 'profile': 'default',
         'nameservers': [], 'ds_info': [{
           "keytag": 37610,
           "algorithm":8,

--- a/src/app/services/dns-check.service.ts
+++ b/src/app/services/dns-check.service.ts
@@ -65,7 +65,7 @@ export class DnsCheckService {
 
   public startDomainTest(data) {
     return this.RPCRequest('start_domain_test', {
-      // language: this.translateService.currentLang,
+      language: this.translateService.currentLang,
       ...data
     });
   }
@@ -89,7 +89,7 @@ export class DnsCheckService {
 
   public fetchFromParent(domain) {
     return this.RPCRequest('get_data_from_parent_zone', {
-      // language: this.translateService.currentLang,
+      language: this.translateService.currentLang,
       domain: domain
     }, false);
   }


### PR DESCRIPTION
## Purpose

Translate backend validation errors

## Context

Depends on https://github.com/zonemaster/zonemaster-backend/pull/891, addresses #239

## Changes

* Add language in param for start_domain_test and fetch_data_from_parent_zone
* Resend form if the form has been touched by the user and is in a invalid state

## How to test this PR

* Fill garbage in the test form and submit it.
* Check that errors are displayed in the selected language (if supported by the backend)
* Change the language
* Check that the errors have also been translated
