### PR TITLE
Fix tests crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Run `npm start` for a dev server. Navigate to `http://localhost:4200/`. The app 
 Run `npm run build` to build the project. The build artifacts will be stored in the `dist/` directory.
 The script also change the FAQ markdown files to html files.
 
+##### Test
+Run the following commands to run the e2e tests, you will need [Google Chrome to be installed](https://github.com/zonemaster/zonemaster/blob/develop/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md).
+  1. Install the webdriver corresponding to you version of Chrome
+     ```sh
+     npx webdriver-manager update --versions.chrome=$(google-chrome --version | sed 's/Google Chrome //')
+     ```
+  2. Run the tests
+     ```sh
+     npm run e2e -- --webdriver-update=false
+     ```
+
 ##### Create a release zip file
 Run 'npm run release' to create a zip file with dist folder and zonemaster.conf file. Then upload it in github.
 

--- a/e2e/FR01.e2e-spec.ts
+++ b/e2e/FR01.e2e-spec.ts
@@ -4,9 +4,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR01 - [A Home button that sends the user to the default simple view]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should have a link to go to home page', () => {

--- a/e2e/FR02.e2e-spec.ts
+++ b/e2e/FR02.e2e-spec.ts
@@ -4,9 +4,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR02 - [All menus should be clickable in latest version of different browsers]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should go to faq page', () => {

--- a/e2e/FR03.e2e-spec.ts
+++ b/e2e/FR03.e2e-spec.ts
@@ -4,9 +4,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR03 - [All appropriate fields should be writable]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should be able to write in the main input', () => {

--- a/e2e/FR04.e2e-spec.ts
+++ b/e2e/FR04.e2e-spec.ts
@@ -4,9 +4,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR04 - Valid title for the Web interface', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should have right title - Zonemaster', () => {

--- a/e2e/FR05-da.e2e-spec.ts
+++ b/e2e/FR05-da.e2e-spec.ts
@@ -14,7 +14,6 @@ describe('Zonemaster test FR05-da - [Supports Danish language]', () => {
 
   it('should switch to Danish', async () => {
     await utils.setLang('da');
-    //expect(element(by.xpath('//h1[.="Domænenavn"]')).isPresent()).toBe(true);
     await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domænenavn"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);

--- a/e2e/FR05-da.e2e-spec.ts
+++ b/e2e/FR05-da.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { by, browser, element } from 'protractor';
+import { by, browser, element, ExpectedConditions } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
@@ -14,7 +14,8 @@ describe('Zonemaster test FR05-da - [Supports Danish language]', () => {
 
   it('should switch to Danish', async () => {
     await utils.setLang('da');
-    expect(element(by.xpath('//h1[.="Domænenavn"]')).isPresent()).toBe(true);
+    //expect(element(by.xpath('//h1[.="Domænenavn"]')).isPresent()).toBe(true);
+    await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domænenavn"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);
     expect(selectedLang.first().getAttribute('lang')).toBe('da');

--- a/e2e/FR05-en.e2e-spec.ts
+++ b/e2e/FR05-en.e2e-spec.ts
@@ -14,7 +14,6 @@ describe('Zonemaster test FR05-en - [Supports English language]', () => {
 
   it('should switch to English', async () => {
     await utils.setLang('en');
-    //expect(element(by.xpath('//h1[.="Domain name"]')).isPresent()).toBe(true);
     await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domain name"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);

--- a/e2e/FR05-en.e2e-spec.ts
+++ b/e2e/FR05-en.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { by, browser, element } from 'protractor';
+import { by, browser, element, ExpectedConditions } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
@@ -14,7 +14,8 @@ describe('Zonemaster test FR05-en - [Supports English language]', () => {
 
   it('should switch to English', async () => {
     await utils.setLang('en');
-    expect(element(by.xpath('//h1[.="Domain name"]')).isPresent()).toBe(true);
+    //expect(element(by.xpath('//h1[.="Domain name"]')).isPresent()).toBe(true);
+    await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domain name"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);
     expect(selectedLang.first().getAttribute('lang')).toBe('en');

--- a/e2e/FR05-fi.e2e-spec.ts
+++ b/e2e/FR05-fi.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { by, browser, element } from 'protractor';
+import { by, browser, element, ExpectedConditions } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
@@ -14,7 +14,8 @@ describe('Zonemaster test FR05-fi - [Supports Finnish language]', () => {
 
   it('should switch to Finnish', async () => {
     await utils.setLang('fi');
-    expect(element(by.xpath('//h1[.="Verkkotunnus"]')).isPresent()).toBe(true);
+    //expect(element(by.xpath('//h1[.="Verkkotunnus"]')).isPresent()).toBe(true);
+    await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Verkkotunnus"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);
     expect(selectedLang.first().getAttribute('lang')).toBe('fi');

--- a/e2e/FR05-fi.e2e-spec.ts
+++ b/e2e/FR05-fi.e2e-spec.ts
@@ -14,7 +14,6 @@ describe('Zonemaster test FR05-fi - [Supports Finnish language]', () => {
 
   it('should switch to Finnish', async () => {
     await utils.setLang('fi');
-    //expect(element(by.xpath('//h1[.="Verkkotunnus"]')).isPresent()).toBe(true);
     await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Verkkotunnus"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);

--- a/e2e/FR05-fr.e2e-spec.ts
+++ b/e2e/FR05-fr.e2e-spec.ts
@@ -16,7 +16,6 @@ describe('Zonemaster test FR05-fr - [Supports French language]', () => {
 
   it('should switch to French', async () => {
     await utils.setLang('fr');
-    //expect(element(by.xpath('//h1[.="Nom de domaine"]')).isPresent()).toBe(true);
     await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Nom de domaine"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);

--- a/e2e/FR05-fr.e2e-spec.ts
+++ b/e2e/FR05-fr.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { by, browser, element } from 'protractor';
+import { by, browser, element, ExpectedConditions } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
@@ -16,7 +16,8 @@ describe('Zonemaster test FR05-fr - [Supports French language]', () => {
 
   it('should switch to French', async () => {
     await utils.setLang('fr');
-    expect(element(by.xpath('//h1[.="Nom de domaine"]')).isPresent()).toBe(true);
+    //expect(element(by.xpath('//h1[.="Nom de domaine"]')).isPresent()).toBe(true);
+    await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Nom de domaine"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);
     expect(selectedLang.first().getAttribute('lang')).toBe('fr');

--- a/e2e/FR05-nb.e2e-spec.ts
+++ b/e2e/FR05-nb.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { by, browser, element } from 'protractor';
+import { by, browser, element, ExpectedConditions } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
@@ -14,7 +14,8 @@ describe('Zonemaster test FR05-nb - [Supports Norwegian language]', () => {
 
   it('should switch to Norwegian', async () => {
     await utils.setLang('nb');
-    expect(element(by.xpath('//h1[.="Domenenavn"]')).isPresent()).toBe(true);
+    //expect(element(by.xpath('//h1[.="Domenenavn"]')).isPresent()).toBe(true);
+    await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domenenavn"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);
     expect(selectedLang.first().getAttribute('lang')).toBe('nb');

--- a/e2e/FR05-nb.e2e-spec.ts
+++ b/e2e/FR05-nb.e2e-spec.ts
@@ -14,7 +14,6 @@ describe('Zonemaster test FR05-nb - [Supports Norwegian language]', () => {
 
   it('should switch to Norwegian', async () => {
     await utils.setLang('nb');
-    //expect(element(by.xpath('//h1[.="Domenenavn"]')).isPresent()).toBe(true);
     await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domenenavn"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);

--- a/e2e/FR05-sv.e2e-spec.ts
+++ b/e2e/FR05-sv.e2e-spec.ts
@@ -14,7 +14,6 @@ describe('Zonemaster test FR05-sv - [Supports Swedish language]', () => {
 
   it('should switch to Swedish', async () => {
     await utils.setLang('sv');
-    //expect(element(by.xpath('//h1[.="Domännamn"]')).isPresent()).toBe(true);
     await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domännamn"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);

--- a/e2e/FR05-sv.e2e-spec.ts
+++ b/e2e/FR05-sv.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { by, browser, element } from 'protractor';
+import { by, browser, element, ExpectedConditions } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
@@ -14,7 +14,8 @@ describe('Zonemaster test FR05-sv - [Supports Swedish language]', () => {
 
   it('should switch to Swedish', async () => {
     await utils.setLang('sv');
-    expect(element(by.xpath('//h1[.="Domännamn"]')).isPresent()).toBe(true);
+    //expect(element(by.xpath('//h1[.="Domännamn"]')).isPresent()).toBe(true);
+    await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domännamn"]'))), 5 * 1000);
     const selectedLang = element.all(by.css('nav div.lang a.selected'));
     expect(selectedLang.count()).toBe(1);
     expect(selectedLang.first().getAttribute('lang')).toBe('sv');

--- a/e2e/FR08.e2e-spec.ts
+++ b/e2e/FR08.e2e-spec.ts
@@ -1,15 +1,15 @@
-import { by, browser, element } from 'protractor';
+import { by, browser, element, ExpectedConditions } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR08 - [Presence of a default fallback language - English]', () => {
   const utils = new Utils();
   beforeAll(async () => {
+    await utils.goToHome();
     await utils.clearBrowserCache();
-    utils.goToHome();
   });
 
-  it('should have a fallback language - English', () => {
-    expect(element(by.xpath('//h1[.="Domain name"]')).isPresent()).toBe(true);
+  it('should have a fallback language - English', async () => {
+    await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domain name"]'))), 5 * 1000);
   });
 });

--- a/e2e/FR09.e2e-spec.ts
+++ b/e2e/FR09.e2e-spec.ts
@@ -4,9 +4,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR09 - [Once a language is chosen, all other links should open in that respective language]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('fr');
+  beforeAll(async ()=> {
+    await utils.goToHome();
+    await utils.setLang('fr');
   });
 
   it('should keep french when opening faq page', async() => {

--- a/e2e/FR10.e2e-spec.ts
+++ b/e2e/FR10.e2e-spec.ts
@@ -1,15 +1,15 @@
-import { by, browser, element } from 'protractor';
+import { by, browser, element, ExpectedConditions } from 'protractor';
 
 import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR10 - [On launching the URL opens with a default simple view]', () => {
   const utils = new Utils();
   beforeAll(async () => {
+    await utils.goToHome();
     await utils.clearBrowserCache();
-    utils.goToHome();
   });
-  it('should have [Domain name] label visible', () => {
-    expect(element(by.xpath('//h1[(.="Domain name")]')).isPresent()).toBe(true);
+  it('should have [Domain name] label visible', async () => {
+    await browser.wait(() => ExpectedConditions.presenceOf(element(by.xpath('//h1[.="Domain name"]'))), 5 * 1000);
   });
   it('should have [Options] label visible and NOT selected', () => {
     expect(element(by.xpath('//label[contains(., "Options")]')).isPresent()).toBe(true);

--- a/e2e/FR11.e2e-spec.ts
+++ b/e2e/FR11.e2e-spec.ts
@@ -4,9 +4,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR11 - [The simple view should look the same in latest version of different browsers]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should match the domain page', async() => {

--- a/e2e/FR12.e2e-spec.ts
+++ b/e2e/FR12.e2e-spec.ts
@@ -4,9 +4,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR12 - [The simple view should support an advanced view expanding when the checkbox is enabled]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should have [Disable IPv4 checkbox] && [Disable IPv6 checkbox] NOT visible', () => {

--- a/e2e/FR13.e2e-spec.ts
+++ b/e2e/FR13.e2e-spec.ts
@@ -4,10 +4,10 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR13 - [The advanced view should support the possibility of enabling or disabling IPv4 or IPv6]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
-    utils.activeOptions();
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
+    await utils.activeOptions();
   });
 
   it('should have [Disable IPv4 checkbox] visible and are disable', () => {

--- a/e2e/FR14.e2e-spec.ts
+++ b/e2e/FR14.e2e-spec.ts
@@ -4,10 +4,10 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR14 - [The advanced view should support the possibility of choosing a profile from multiple profiles]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
-    utils.activeOptions();
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
+    await utils.activeOptions();
   });
 
   it('should have an select form with at least one choice (default)', () => {

--- a/e2e/FR15.e2e-spec.ts
+++ b/e2e/FR15.e2e-spec.ts
@@ -4,10 +4,10 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR15 - [The advanced view should look the same in latest version of different browsers]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
-    utils.activeOptions();
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
+    await utils.activeOptions();
   });
 
   it('should match the domain page with options on', () => {

--- a/e2e/FR17.e2e-spec.ts
+++ b/e2e/FR17.e2e-spec.ts
@@ -4,10 +4,10 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR17 - [Able to specify delegation parameters]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
-    utils.activeOptions();
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
+    await utils.activeOptions();
   });
 
   it('should be have one ns and digest form', () => {

--- a/e2e/FR18.e2e-spec.ts
+++ b/e2e/FR18.e2e-spec.ts
@@ -7,9 +7,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR18 - [The GUI should be able to run tests by just providing the domain name]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should display progress bar',  async() => {

--- a/e2e/FR19.e2e-spec.ts
+++ b/e2e/FR19.e2e-spec.ts
@@ -7,11 +7,11 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR19 - [The GUI should be able to run the test with at least one name server as input]', () => {
   const utils = new Utils();
-  beforeEach(() => {
-    utils.goTo('faq');
-    utils.goToHome();
-    utils.setLang('en');
-    utils.activeOptions();
+  beforeEach(async () => {
+    await utils.goTo('faq');
+    await utils.goToHome();
+    await utils.setLang('en');
+    await utils.activeOptions();
   });
 
   it('should NOT display progress bar when we add a NS ip',  async() => {

--- a/e2e/FR20.e2e-spec.ts
+++ b/e2e/FR20.e2e-spec.ts
@@ -7,10 +7,10 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR20 - [The user must be able to submit one or more DS record(s) for use with DNSSEC]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
-    utils.activeOptions();
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
+    await utils.activeOptions();
   });
 
   it('should display progress bar when we add a DS entry and launch a test',  async() => {

--- a/e2e/FR21.e2e-spec.ts
+++ b/e2e/FR21.e2e-spec.ts
@@ -9,9 +9,9 @@ describe('Zonemaster test FR21 - [Able to provide a summarized result of the tes
   '(possibility in different colours for error, warning, success etc.)]', () => {
   const utils = new Utils();
   beforeAll(async () => {
-    utils.goToHome();
+    await utils.goToHome();
     await utils.setLang('en');
-    utils.activeOptions();
+    await utils.activeOptions();
     await utils.clearBrowserCache();
   });
 

--- a/e2e/FR22.e2e-spec.ts
+++ b/e2e/FR22.e2e-spec.ts
@@ -8,9 +8,9 @@ import { Utils } from './utils/app.utils';
 describe('Zonemaster test FR22 - [Provide the possibility to see more information about encountered errors ' +
   'within the simple view]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should display full messages',  async() => {

--- a/e2e/FR23.e2e-spec.ts
+++ b/e2e/FR23.e2e-spec.ts
@@ -8,9 +8,9 @@ import { Utils } from './utils/app.utils';
 describe('Zonemaster test FR23 - [Provide a list of previous runs for the domain and should be paginated]', () => {
   const utils = new Utils();
   const EC = protractor.ExpectedConditions;
-  beforeAll(() => {
-    utils.goTo('result/2005cf23e9fb24b6');
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goTo('result/2005cf23e9fb24b6');
+    await utils.setLang('en');
   });
 
   it('should display previous tests',  async() => {
@@ -31,8 +31,3 @@ describe('Zonemaster test FR23 - [Provide a list of previous runs for the domain
 
   });
 });
-
-
-
-
-

--- a/e2e/FR24.e2e-spec.ts
+++ b/e2e/FR24.e2e-spec.ts
@@ -8,9 +8,9 @@ import { Utils } from './utils/app.utils';
 describe('Zonemaster test FR24 - [The list of previous runs should contain links to the previous tests]', () => {
   const utils = new Utils();
   const EC = protractor.ExpectedConditions;
-  beforeAll(() => {
-    utils.goTo('result/2005cf23e9fb24b6');
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goTo('result/2005cf23e9fb24b6');
+    await utils.setLang('en');
   });
 
   it('should display previous run link',  async() => {

--- a/e2e/FR25.e2e-spec.ts
+++ b/e2e/FR25.e2e-spec.ts
@@ -7,9 +7,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR25 - [Should be able to export the result in multiple formats (HTML, CSV, JSON, TEXT)]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goTo('result/2005cf23e9fb24b6');
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goTo('result/2005cf23e9fb24b6');
+    await utils.setLang('en');
   });
 
   it('should have an export button',  async() => {
@@ -30,8 +30,3 @@ describe('Zonemaster test FR25 - [Should be able to export the result in multipl
     await expect(element.all(by.css('button.btn.export + div.show button.btn')).get(3).getText()).toEqual('TEXT');
   });
 });
-
-
-
-
-

--- a/e2e/FR26.e2e-spec.ts
+++ b/e2e/FR26.e2e-spec.ts
@@ -7,9 +7,9 @@ import { Utils } from './utils/app.utils';
 
 describe('Zonemaster test FR26 - [Should be able to show a progress bar with a rough estimate of the total test progress]', () => {
   const utils = new Utils();
-  beforeAll(() => {
-    utils.goToHome();
-    utils.setLang('en');
+  beforeAll(async () => {
+    await utils.goToHome();
+    await utils.setLang('en');
   });
 
   it('should display progress bar',  async() => {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,13 +19,13 @@ module.exports = function (config) {
       dir: require('path').join(__dirname, 'coverage'), reports: [ 'html', 'lcovonly' ],
       fixWebpackSourcePaths: true
     },
-    
+
     reporters: ['progress', 'kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
-    singleRun: false
+    singleRun: false,
   });
 };

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -26,10 +26,13 @@ exports.config = {
     'chromeOptions': {
       'args': [
         '--headless',
-        '--disk-cache-dir=/dev/null',
+        '--no-sandbox',
+        '--disable-gpu',
+        '--disable-extension',
+        '--incogito',
         '--disable-web-security',
         '--window-size=1920,1080',
-        'lang=es-AR'
+        '--lang=es-AR'
       ]
     }
   }],
@@ -60,9 +63,7 @@ exports.config = {
     require('ts-node').register({
       project: 'e2e/tsconfig.e2e.json'
     });
-    jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: false } }));
+    jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: 'none' } }));
     browser.ignoreSynchronization = true
   }
 };
-
-

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -29,7 +29,7 @@ exports.config = {
         '--no-sandbox',
         '--disable-gpu',
         '--disable-extension',
-        '--incogito',
+        '--incognito',
         '--disable-web-security',
         '--window-size=1920,1080',
         '--lang=es-AR'


### PR DESCRIPTION
## Purpose

* Fix tests crash with chrome 95
* Improve test reliability with async operations

## Context

Test on develop are not passing

## Changes

* Change chrome argument `--disk-cache-dir=/dev/null'` for `--incogito` and 
* Add a few other chrome arguments to make running tests less prone to failure (disable user extension, don't use gpu acceleration, disable sandboxing)
* Remove jasmine warning concerning the `displayStacktrace` option
* Wait for `beforeAll` instructions
* Wait for translation to be loaded when searching for specific strings

## How to test this PR

Run e2e tests with chrome 95: 
```
node ./node_modules/.bin/webdriver-manager update --versions.chrome=$(google-chrome --version | sed 's/Google Chrome //')
npm run e2e -- --webdriver-update=false
```
