### PR TITLE
Missing Ubuntu OS in link

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -23,7 +23,7 @@ installation].
 This instruction covers the following operating systems:
 
  1. [CentOS](#1-centos)
- 2. [Debian](#2-debian-and-ubuntu)
+ 2. [Debian and Ubuntu](#2-debian-and-ubuntu)
  3. [FreeBSD](#3-freebsd)
 
 


### PR DESCRIPTION
## Purpose

Ubuntu is not explicitly stated in the covered OSs.

## Context

Fix missing OS.

## Changes

Update the installation document.

## How to test this PR

Documentation only. Nothing to test.
