### PR TITLE
Properly translate all placeholders

### DIFF
--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -157,7 +157,7 @@
               <div class="col-md-3">
                 <select formControlName="algorithm" class="form-control"
                         [class.is-invalid]="ds_info.controls.algorithm.invalid && (ds_info.controls.algorithm.dirty || ds_info.controls.algorithm.touched)">
-                  <option [value]="-1" selected disabled hidden>{{'Algorithm' | translate}}</option>
+                  <option [value]="-1" selected disabled>{{'Algorithm' | translate}}</option>
                   <option [value]="1">1 - RSAMD5</option>
                   <option [value]="3">3 - DSA</option>
                   <option [value]="5">5 - RSASHA1</option>
@@ -182,7 +182,7 @@
               <div class="col-md-2">
                 <select formControlName="digtype" class="form-control"
                         [class.is-invalid]="ds_info.controls.digtype.invalid && (ds_info.controls.digtype.dirty || ds_info.controls.digtype.touched)">
-                  <option [value]="-1" selected disabled hidden> {{'Digest type' | translate}} </option>
+                  <option [value]="-1" selected disabled> {{'Digest type' | translate}} </option>
                   <option [value]="1">1 - SHA-1</option>
                   <option [value]="2">2 - SHA-256</option>
                   <option [value]="3">3 - GOST R 34.11-94</option>


### PR DESCRIPTION
## Purpose

Some placeholders are not properly translated (due to limitation from the browser). Removing the hidden HTML property would fix this issue.

## Context

Addresses #277 

## Changes

Remove the hidden property.

## How to test this PR

Repeat this on Firefox, Chrome and mobile device:

1. open the options
2. change the language
3. check that the "Algorithm" and "Digest type" are properly translated
