### PR TITLE
use webpack import to load translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@angular/router": "^10.2.5",
         "@ng-bootstrap/ng-bootstrap": "^8.0.0",
         "@ngx-translate/core": "^13.0.0",
-        "@ngx-translate/http-loader": "^6.0.0",
         "@types/resize-observer-browser": "^0.1.6",
         "bootstrap": "^4.3.1",
         "core-js": "^3.2.1",
@@ -2799,19 +2798,6 @@
       },
       "peerDependencies": {
         "@angular/core": ">=10.0.0",
-        "rxjs": ">=6.5.3"
-      }
-    },
-    "node_modules/@ngx-translate/http-loader": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
-      "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": ">=10.0.0",
-        "@ngx-translate/core": ">=13.0.0",
         "rxjs": ">=6.5.3"
       }
     },
@@ -15078,7 +15064,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15094,19 +15080,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15121,7 +15107,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15139,7 +15125,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -26675,14 +26661,6 @@
         "tslib": "^2.0.0"
       }
     },
-    "@ngx-translate/http-loader": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
-      "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -36455,7 +36433,7 @@
         "lodash._baseindexof": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -36469,17 +36447,17 @@
         "lodash._bindcallback": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -36492,7 +36470,7 @@
         "lodash._getnative": {
           "version": "3.9.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -36507,7 +36485,7 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@angular/router": "^10.2.5",
     "@ng-bootstrap/ng-bootstrap": "^8.0.0",
     "@ngx-translate/core": "^13.0.0",
-    "@ngx-translate/http-loader": "^6.0.0",
     "@types/resize-observer-browser": "^0.1.6",
     "bootstrap": "^4.3.1",
     "core-js": "^3.2.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,11 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule, Routes } from '@angular/router';
-import { HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
-import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Observable, from } from 'rxjs';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
@@ -44,8 +44,14 @@ import { HttpMockRequestInterceptor } from './interceptors/mock.interceptor';
 export const isMock = environment.mock;
 
 // AoT requires an exported function for factories
-export function HttpLoaderFactory(http: HttpClient) {
-  return new TranslateHttpLoader(http, `assets/i18n/`, '.json');
+export function TranslationLoaderFactory() {
+  return new MyTranslationLoader();
+}
+
+class MyTranslationLoader extends TranslateLoader {
+  getTranslation(lang: string): Observable<any> {
+    return from(import(/* webpackChunkName: "i18n-[request]" */ `../assets/i18n/${lang}.json`));
+  }
 }
 
 const appRoutes: Routes = [
@@ -88,8 +94,7 @@ const appRoutes: Routes = [
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,
-        useFactory: HttpLoaderFactory,
-        deps: [HttpClient]
+        useFactory: TranslationLoaderFactory,
       }
     }),
     RouterModule.forRoot(


### PR DESCRIPTION
## Purpose

Prevent translation caching when the translation are updated.

## Context

#283 

## Changes

Use webpack `import` to load the translation, this adds a hash after the file name.

```
chunk {2} i18n-en-json-es2015.f8c41b236b7e77398141.js (i18n-en-json) 4.5 kB  [rendered]
chunk {2} i18n-en-json-es5.f8c41b236b7e77398141.js (i18n-en-json) 4.5 kB  [rendered]
chunk {1} i18n-da-json-es2015.561f401761dab618b7f2.js (i18n-da-json) 4.59 kB  [rendered]
chunk {1} i18n-da-json-es5.561f401761dab618b7f2.js (i18n-da-json) 4.59 kB  [rendered]
chunk {3} i18n-fi-json-es2015.28e026616c18fa840bf8.js (i18n-fi-json) 4.22 kB  [rendered]
chunk {3} i18n-fi-json-es5.28e026616c18fa840bf8.js (i18n-fi-json) 4.22 kB  [rendered]
chunk {6} i18n-sv-json-es2015.9c07614a0c8c0ee52778.js (i18n-sv-json) 4.87 kB  [rendered]
chunk {6} i18n-sv-json-es5.9c07614a0c8c0ee52778.js (i18n-sv-json) 4.87 kB  [rendered]
chunk {4} i18n-fr-json-es2015.935c4d81daf86b406691.js (i18n-fr-json) 5.24 kB  [rendered]
chunk {4} i18n-fr-json-es5.935c4d81daf86b406691.js (i18n-fr-json) 5.24 kB  [rendered]
```

## How to test this PR
Build and serve a release bundle, check that changing the language works correctly and that the name of the file contains a hash.
