### PR TITLE
Sort messages by severity

### DIFF
--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -164,7 +164,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
 
       for (const module in this.module_items) {
         this.module_items[module].sort((msg1, msg2) => {
-          // sort messages by descending serverity level
+          // sort messages by descending severity level
           return this.levelSeverity.indexOf(msg2.level) - this.levelSeverity.indexOf(msg1.level);
         })
       }

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -162,6 +162,13 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
         this.level_items[item['level'].toLowerCase()].push(item);
       }
 
+      for (const module in this.module_items) {
+        this.module_items[module].sort((msg1, msg2) => {
+          // sort messages by descending serverity level
+          return this.levelSeverity.indexOf(msg2.level) - this.levelSeverity.indexOf(msg1.level);
+        })
+      }
+
       this.form = data['params'];
       this.ns_list = data['ns_list'];
       this.ds_list = data['ds_list'];


### PR DESCRIPTION
## Purpose

Show higher severity level messages first.

## Context

Suggested as a workaround for issue #118

## Changes

The message or sorted in place by severity before being displayed.

## How to test this PR

Test a domain that output different message with different severity level.

Output bellow generated by testing `ppsfleet.navy` in undelegated mode, the data was fetched from the nameserver, `ns3.ppsfleet.navy` removed from the ns list and `fake.ppsfleet.navy` pointing to 127.0.0.1 was added.

![Screenshot 2022-01-24 at 16-12-23 Zonemaster](https://user-images.githubusercontent.com/19394895/150809798-5e0f77e4-2171-4985-a7da-763acd073539.png)

