### PR TITLE
make polling interval configurable

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,3 +32,4 @@ The supported configuration items are the following.
   banner will be shown. HTML formatting is supported (such as `<a>` tag) and
   some characters such as `&><` need to be written as HTML codes to be properly
   rendered.
+* `"pollingInterval"`: Time between each test progress query.

--- a/src/app/components/domain-check/domain-check.component.ts
+++ b/src/app/components/domain-check/domain-check.component.ts
@@ -3,6 +3,7 @@ import { DnsCheckService } from '../../services/dns-check.service';
 import { Router} from '@angular/router';
 import { AlertService } from '../../services/alert.service';
 import { TranslateService } from '@ngx-translate/core';
+import { AppService } from '../../services/app.service';
 
 @Component({
   selector: 'app-domain-check',
@@ -10,7 +11,7 @@ import { TranslateService } from '@ngx-translate/core';
   styleUrls: ['./domain-check.component.css']
 })
 export class DomainCheckComponent implements OnInit {
-  private intervalTime = 5 * 1000;
+  private intervalTime: number;
   public is_advanced_options_enabled = false;
   public domain_check_progression = 0;
   public showResult = false;
@@ -24,7 +25,10 @@ export class DomainCheckComponent implements OnInit {
   constructor(private alertService: AlertService,
     private dnsCheckService: DnsCheckService,
     private translateService: TranslateService,
-    private router: Router) {}
+    private router: Router,
+    private appService: AppService) {
+      this.intervalTime = this.appService.getConfig('pollingInterval');
+    }
 
   ngOnInit() {
     this.dnsCheckService.profileNames().then( (res: string[]) => this.profiles = res );

--- a/src/environments/common.ts
+++ b/src/environments/common.ts
@@ -15,5 +15,6 @@ export const common = {
     'sv': 'Svenska'
   },
   enabledLanguages: [ 'da', 'en', 'es', 'fi', 'fr', 'nb', 'sv' ],
-  configUrl: 'assets/app.config.json'
+  configUrl: 'assets/app.config.json',
+  pollingInterval: 5 * 1000,
 }

--- a/src/environments/environment.tests.ts
+++ b/src/environments/environment.tests.ts
@@ -6,5 +6,6 @@ export const environment = {
   apiEndpoint: 'https://zonemaster.net/api',
   mock: true,
   // Use a non existent file to always load the config from the environment file
-  configUrl: 'assets/app.config.non-existent.json'
+  configUrl: 'assets/app.config.non-existent.json',
+  pollingInterval: 0.1 * 1000,
 };


### PR DESCRIPTION
## Purpose

Speed up e2e tests that start domain tests.

## Context



## Changes

The test introduced in https://github.com/zonemaster/zonemaster-gui/pull/300 is quite slow as it is starting 3 tests, this reduces the polling interval in tests environment.

## How to test this PR

Run the e2e tests.
