### PR TITLE
translate faq title

### DIFF
--- a/src/app/components/faq/faq.component.html
+++ b/src/app/components/faq/faq.component.html
@@ -1,5 +1,5 @@
 <app-header>
-  <h1>FAQ</h1>
+  <h1>{{'FAQ' | translate}}</h1>
 </app-header>
 <div class="container faq">
   <div [innerHtml]="faqTemplate | safeHtml">

--- a/src/app/components/faq/faq.component.ts
+++ b/src/app/components/faq/faq.component.ts
@@ -22,24 +22,15 @@ export class FaqComponent implements OnInit, OnDestroy, AfterViewChecked {
               private translateService: TranslateService,
               private route: ActivatedRoute,
               private titleService: Title) {
+
     this.langChangeSubscription = this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
-      this.url = `assets/faqs/gui-faq-${event.lang}.html`;
-      this._http.get(this.url, {responseType: 'text'})
-        .subscribe(data => {
-          this.faqTemplate = data;
-        });
+      this.loadFaq(event.lang)
     });
   }
 
   ngOnInit() {
-    this.url = `assets/faqs/gui-faq-${this.translateService.currentLang}.html`;
-    this._http.get(this.url, {responseType: 'text'})
-      .subscribe(data => {
-        this.faqTemplate = data;
-      });
-
+    this.loadFaq(this.translateService.currentLang);
     this.fragmentSubscription = this.route.fragment.subscribe(fragment => { this.fragment = fragment; });
-    this.titleService.setTitle('FAQ · Zonemaster');
   }
 
   ngOnDestroy() {
@@ -52,5 +43,18 @@ export class FaqComponent implements OnInit, OnDestroy, AfterViewChecked {
       document.querySelector('a[name="' + this.fragment + '"]').scrollIntoView();
       this.fragment = '';
     } catch (e) {}
+  }
+
+  loadFaq(lang) {
+    this.url = `assets/faqs/gui-faq-${lang}.html`;
+
+    this._http.get(this.url, {responseType: 'text'})
+      .subscribe(data => {
+        this.faqTemplate = data;
+      });
+
+    this.translateService.get('FAQ').subscribe((faqTitle: string) => {
+      this.titleService.setTitle(`${faqTitle} · Zonemaster`);
+    });
   }
 }


### PR DESCRIPTION
## Purpose

Use translated title instead of untranslated 'FAQ' for the FAQ page.

## Context

https://github.com/zonemaster/zonemaster-gui/pull/310#issuecomment-1111049570

## Changes

* Translate 'FAQ' in `title` and `h1` (only affected locale is Finnish)

![Screenshot_20220428_095520](https://user-images.githubusercontent.com/19394895/165704999-68f5a268-b542-4765-a86d-0aa89066999d.png)


## How to test this PR

Check that the title of the page and the page header are translated for the FAQ page.
