### PR TITLE
Translates "FAQ" to Swedish

### DIFF
--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -22,7 +22,7 @@
     "Domain name required": "Domännamn måste anges",
     "Error during parent data fetching": "Fel när data skulle hämtas från moderzonen",
     "Export": "Export",
-    "FAQ": "FAQ",
+    "FAQ": "Vanliga frågor",
     "Fetch data from parent zone": "Hämta data från föräldrazonen",
     "Filter text": "Filtrera meddelanden",
     "History": "Tidigare test",


### PR DESCRIPTION
## Purpose

Give a friendlier title to the Swedish FAQ page.

Also see change introduced by #313.

## Changes

Updates sv.json.

## How to test this PR

Open the FAQ page and see the heading in Swedish.
