### PR TITLE
use new property created_at when displaying history

### DIFF
--- a/src/app/components/history/history.component.ts
+++ b/src/app/components/history/history.component.ts
@@ -36,7 +36,7 @@ export class HistoryComponent implements OnInit {
       } else if ('ok' === item.overall_result) {
         item.color = 'success';
       }
-      item.local_creation_time = new Date(item.creation_time + 'Z');
+      item.local_creation_time = new Date(item.created_at);
       return item;
     });
   }

--- a/src/app/interceptors/mock.interceptor.ts
+++ b/src/app/interceptors/mock.interceptor.ts
@@ -187,7 +187,33 @@ const urls = [
     url: 'https://zonemaster.net/api',
     body: {'jsonrpc': '2.0', 'id': 1572271917712, 'method': 'get_test_history', 'params': {'offset': 0, 'limit': 100, 'filter': 'all', 'frontend_params': {'domain': 'results.afNiC.Fr'}}},
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572271917712, 'result': [{'overall_result': 'error', 'creation_time': '2019-10-28 09:42:42.432378', 'id': '293f626579274f18'}, {'overall_result': 'ok', 'creation_time': '2019-10-28 09:24:57.395431', 'id': '84bfac6ae74d0e62'}, {'overall_result': 'ok', 'creation_time': '2019-10-24 07:49:48.079617', 'id': 'efe0931716b0068c'}, {'overall_result': 'ok', 'creation_time': '2019-10-24 07:49:16.271481', 'id': '46acbdcbc456db1d'}, {'overall_result': 'ok', 'creation_time': '2019-10-24 07:35:52.819536', 'id': 'fd5b10ae1a46ce5e'}, {'overall_result': 'ok', 'creation_time': '2019-10-24 07:35:21.309154', 'id': '1b29b0582a99d7ab'}, {'overall_result': 'ok', 'creation_time': '2019-10-24 06:51:22.373411', 'id': '8c4829b7f60edc25'}, {'overall_result': 'ok', 'creation_time': '2019-10-24 06:50:50.801272', 'id': '9b89a0988dbccfdb'}, {'overall_result': 'ok', 'creation_time': '2019-10-24 06:39:37.48699', 'id': '89c662ddd43a8b03'}, {'overall_result': 'ok', 'creation_time': '2019-10-24 06:39:05.851497', 'id': '2add42a68594b37a'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 20:59:41.594768', 'id': 'c334d7eb96af1d19'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 20:55:13.205118', 'id': 'b4146c79de8b3638'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 20:46:06.989113', 'id': '226f6d4f44ae3f80'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 20:40:46.272244', 'id': 'a509e33a41f28322'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 20:34:21.681947', 'id': '5d41c57fa24c76f5'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 20:28:25.518303', 'id': '298b4c53d5024f44'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 20:16:39.466781', 'id': 'f9c587426b885036'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 19:41:31.048622', 'id': 'bb2109eb54d9ef58'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 16:20:56.180064', 'id': '3ff7e65752a431e8'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 15:37:05.935049', 'id': 'e8a3507cce49392d'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 15:25:35.162808', 'id': '19f7773777cdad1a'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 15:09:54.801371', 'id': '61907eb87c8bb1d9'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 14:52:56.823486', 'id': '497ce5549e80d6d1'}, {'overall_result': 'ok', 'creation_time': '2019-10-23 14:39:25.259204', 'id': '470e62da84dcbd16'}, {'overall_result': 'error', 'creation_time': '2019-10-23 14:26:35.853106', 'id': '9b8e25c35dc365ac'}]}
+    json: {'jsonrpc': '2.0', 'id': 1572271917712, 'result': [
+      {'overall_result': 'error', 'created_at': '2019-10-28T09:24:57Z', 'creation_time': '2019-10-28 09:42:42.432378', 'id': '293f626579274f18'},
+      {'overall_result': 'ok', 'created_at': '2019-10-28T09:24:57Z', 'creation_time': '2019-10-28 09:24:57.395431', 'id': '84bfac6ae74d0e62'},
+      {'overall_result': 'ok', 'created_at': '2019-10-24T07:49:48Z', 'creation_time': '2019-10-24 07:49:48.079617', 'id': 'efe0931716b0068c'},
+      {'overall_result': 'ok', 'created_at': '2019-10-24T07:49:16Z', 'creation_time': '2019-10-24 07:49:16.271481', 'id': '46acbdcbc456db1d'},
+      {'overall_result': 'ok', 'created_at': '2019-10-24T07:35:52Z', 'creation_time': '2019-10-24 07:35:52.819536', 'id': 'fd5b10ae1a46ce5e'},
+      {'overall_result': 'ok', 'created_at': '2019-10-24T07:35:21Z', 'creation_time': '2019-10-24 07:35:21.309154', 'id': '1b29b0582a99d7ab'},
+      {'overall_result': 'ok', 'created_at': '2019-10-24T06:51:22Z', 'creation_time': '2019-10-24 06:51:22.373411', 'id': '8c4829b7f60edc25'},
+      {'overall_result': 'ok', 'created_at': '2019-10-24T06:50:50Z', 'creation_time': '2019-10-24 06:50:50.801272', 'id': '9b89a0988dbccfdb'},
+      {'overall_result': 'ok', 'created_at': '2019-10-24T06:39:37Z', 'creation_time': '2019-10-24 06:39:37.48699', 'id': '89c662ddd43a8b03'},
+      {'overall_result': 'ok', 'created_at': '2019-10-24T06:39:05Z', 'creation_time': '2019-10-24 06:39:05.851497', 'id': '2add42a68594b37a'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T20:59:41Z', 'creation_time': '2019-10-23 20:59:41.594768', 'id': 'c334d7eb96af1d19'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T20:55:13Z', 'creation_time': '2019-10-23 20:55:13.205118', 'id': 'b4146c79de8b3638'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T20:46:06Z', 'creation_time': '2019-10-23 20:46:06.989113', 'id': '226f6d4f44ae3f80'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T20:40:46Z', 'creation_time': '2019-10-23 20:40:46.272244', 'id': 'a509e33a41f28322'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T20:34:21Z', 'creation_time': '2019-10-23 20:34:21.681947', 'id': '5d41c57fa24c76f5'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T20:28:25Z', 'creation_time': '2019-10-23 20:28:25.518303', 'id': '298b4c53d5024f44'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T20:16:39Z', 'creation_time': '2019-10-23 20:16:39.466781', 'id': 'f9c587426b885036'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T19:41:31Z', 'creation_time': '2019-10-23 19:41:31.048622', 'id': 'bb2109eb54d9ef58'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T16:20:56Z', 'creation_time': '2019-10-23 16:20:56.180064', 'id': '3ff7e65752a431e8'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T15:37:05Z', 'creation_time': '2019-10-23 15:37:05.935049', 'id': 'e8a3507cce49392d'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T15:25:35Z', 'creation_time': '2019-10-23 15:25:35.162808', 'id': '19f7773777cdad1a'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T15:09:54Z', 'creation_time': '2019-10-23 15:09:54.801371', 'id': '61907eb87c8bb1d9'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T14:52:56Z', 'creation_time': '2019-10-23 14:52:56.823486', 'id': '497ce5549e80d6d1'},
+      {'overall_result': 'ok', 'created_at': '2019-10-23T14:39:25Z', 'creation_time': '2019-10-23 14:39:25.259204', 'id': '470e62da84dcbd16'},
+      {'overall_result': 'error', 'created_at': '2019-10-23T14:26:35Z', 'creation_time': '2019-10-23 14:26:35.853106', 'id': '9b8e25c35dc365ac'}
+    ]}
   },
 ];
 


### PR DESCRIPTION
## Purpose

* Avoid work around when parsing time.
* Move away from newly deprecated property.

## Context

Use new API property from https://github.com/zonemaster/zonemaster-backend/pull/967

## Changes

Use `created_at` instead of `creation_time` as it is already in the right format.

## How to test this PR

* run a test
* query the history
* check that the time is correctly displayed and in the local timezone.
