### PR TITLE
use created_at instead of deprecated creation_time in result

### DIFF
--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -131,7 +131,7 @@ export class ResultComponent implements OnInit, OnDestroy {
 
       this.test = {
         id: data['hash_id'],
-        creation_time: new Date(data['creation_time'] + 'Z'),
+        creation_time: new Date(data['created_at']),
         location: document.location.origin + this.location.prepareExternalUrl(`/result/${domainCheckId}`)
       };
 


### PR DESCRIPTION
## Purpose

* `creation_time` is deprecated, use `created_at` instead
* avoid workaround when parsing dates

## Context

* Use new API property from https://github.com/zonemaster/zonemaster-backend/pull/967

## Changes

Use `created_at` instead of `creation_time` 

## How to test this PR
* run a test
* check that the time of the test is correctly displayed and in the local timezone.
