### PR TITLE
Fix FAQ links when serving from custom base

### DIFF
--- a/scripts/faq.js
+++ b/scripts/faq.js
@@ -8,7 +8,7 @@ const markdown_to_html = (text) => {
   const faqHref = {
     type: 'output',
     regex: new RegExp('href="#', 'g'),
-    replace: 'href="/faq#'
+    replace: 'href="./faq#'
   }
   const converter = new showdown.Converter({
     extensions: [faqHref],
@@ -36,4 +36,3 @@ fs.readdir('./src/assets/i18n', (err, files) => {
     getFaq(filename.split('.')[0]);
   });
 });
-


### PR DESCRIPTION
## Purpose

Fix FAQ navigation.

## Context

From mailing list
> when bringing up the FAQ, the FAQ direct links still want to go to  hostname/faq#q1 etc, not hostname/zonemaster/faq#q1

## Changes

Use relative url from base url instead of absolute url.

## How to test this PR

* Start the gui with a custom base url, eg. `npm start -- --base-href "/zonemaster/"`
* Go to FAQ page and check that all links in the table of content work correctly.
