### PR TITLE
fix logo customization key name in documentation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -26,7 +26,7 @@ The supported configuration items are the following.
   `[ "da", "en", "es", "fi", "fr", "nb", "sv" ]`.
 * `"contactAddress"`: The contact email address displayed in the footer, default
   `"contact@zonemaster.net"`.
-* `"logo`": The URL to the image displayed in the navigation bar, default
+* `"logoUrl`": The URL to the image displayed in the navigation bar, default
   `"assets/images/zonemaster_logo_2021_color.png"`.
 * `"msgBanner"`: A message to display to the user, if empty or undefined no
   banner will be shown. HTML formatting is supported (such as `<a>` tag) and

--- a/src/assets/app.config.sample.json
+++ b/src/assets/app.config.sample.json
@@ -3,7 +3,7 @@
     "contactAddress": "contact@zonemaster.net",
     "defaultLanguage": "en",
     "enabledLanguages": [ "da", "en", "es", "fi", "fr", "nb", "sv" ],
-    "logo": "assets/images/zonemaster_logo_2021_color.png",
+    "logoUrl": "assets/images/zonemaster_logo_2021_color.png",
     "msgBanner": "",
     "pollingInterval": 5000
 }


### PR DESCRIPTION
## Purpose

Fix the documentation of the configuration.

## Context

The documented key for logo customization is `logo` while it should be `logoUrl`.

## Changes

Change `logo` to `logoUrl` in the sample configuration and documentation.

## How to test this PR

Following the documentation to set a custom logo should work.
