### PR TITLE
Perform a test through the URL directly

### DIFF
--- a/e2e/FR02.e2e-spec.ts
+++ b/e2e/FR02.e2e-spec.ts
@@ -14,8 +14,8 @@ test.describe('Zonemaster test FR02 - [All menus should be clickable in latest v
   });
 
   test('should go to domain page', async ({ page, baseURL }) => {
-    await page.locator('a.nav-link[routerlink="/domain_check"]').click();
-    await expect(page).toHaveURL(baseURL + '/domain_check');
+    await page.locator('a.nav-link[routerlink="/check"]').click();
+    await expect(page).toHaveURL(baseURL + '/check');
   });
 
 });

--- a/e2e/FR09.e2e-spec.ts
+++ b/e2e/FR09.e2e-spec.ts
@@ -12,6 +12,6 @@ test.describe('Zonemaster test FR09 - [Once a language is chosen, all other link
     await expect(page.locator('h1')).toHaveText('Nom de domaine');
     await page.locator('a.nav-link[routerlink="/faq"]').click();
     await expect(page.locator('section.main > div > h1')).toHaveText('FAQ');
-    await expect(page.locator('a.nav-link[routerlink="/domain_check"]')).toHaveText("Test d'un domaine");
+    await expect(page.locator('a.nav-link[routerlink="/check"]')).toHaveText("Test d'un domaine");
   });
 });

--- a/e2e/navigation.e2e-spec.ts
+++ b/e2e/navigation.e2e-spec.ts
@@ -9,7 +9,7 @@ test.describe('Navigation should be consistent and honor browser behaviour', () 
   });
 
   test('ensure navigation to result page is consistent - #300',  async ({ page, baseURL}) => {
-    const domainCheckUrl = baseURL + '/domain_check';
+    const domainCheckUrl = baseURL + '/check';
     const firstTestUrl = baseURL + '/result/226f6d4f44ae3f80';
     const secondTestUrl = baseURL + '/result/a0fbcbf6c5ff5842';
     const firstDomain = 'results.afNiC.Fr';

--- a/e2e/redirect.e2e-spec.ts
+++ b/e2e/redirect.e2e-spec.ts
@@ -1,0 +1,27 @@
+const { test, expect } = require('@playwright/test');
+
+import { goToHome, setLang } from './utils/app.utils';
+
+test.describe('Redirection should properly work', () => {
+  test.beforeEach(async ({ page }) => {
+    await goToHome(page);
+    await setLang(page, 'en');
+  });
+
+  test('/ should redirect to /check', async ({ page, baseURL }) => {
+    await page.goto( baseURL + '/' );
+    await expect(page).toHaveURL( baseURL + '/check' );
+  });
+
+  test('/domain_check should redirect to /check', async ({ page, baseURL }) => {
+    await page.goto( baseURL + '/domain_check' );
+    await expect(page).toHaveURL( baseURL + '/check' );
+  });
+
+  test('/test/<test-id> should redirect to /result/<test-id>', async ({ page, baseURL }) => {
+    const testID = '226f6d4f44ae3f80';
+
+    await page.goto( baseURL + '/test/' + testID );
+    await expect(page).toHaveURL( baseURL + '/result/' + testID );
+  });
+});

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,15 +48,15 @@ class MyTranslationLoader extends TranslateLoader {
 }
 
 const appRoutes: Routes = [
-  { path: 'domain_check', component: DomainComponent },
+  { path: 'check', component: DomainComponent },
   { path: 'result/:resultID', component: ResultComponent },
   { path: 'test/:resultID', component: ResultComponent },
   { path: 'history', component: HistoryComponent },
   { path: 'faq', component: FaqComponent },
-  { path: '',
-    redirectTo: 'domain_check',
-    pathMatch: 'full'
-  },
+
+  { path: 'domain_check', redirectTo: 'check', pathMatch: 'full' },
+  { path: '', redirectTo: 'check', pathMatch: 'full' },
+
   { path: '**', component: PageNotFoundComponent }
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,6 +48,7 @@ class MyTranslationLoader extends TranslateLoader {
 }
 
 const appRoutes: Routes = [
+  { path: 'check/:domain', component: DomainComponent },
   { path: 'check', component: DomainComponent },
   { path: 'result/:resultID', component: ResultComponent },
   { path: 'history', component: HistoryComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -51,7 +51,6 @@ const appRoutes: Routes = [
   { path: 'check/:domain', component: DomainComponent },
   { path: 'check', component: DomainComponent },
   { path: 'result/:resultID', component: ResultComponent },
-  { path: 'history', component: HistoryComponent },
   { path: 'faq', component: FaqComponent },
 
   { path: 'domain_check', redirectTo: 'check', pathMatch: 'full' },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -50,11 +50,11 @@ class MyTranslationLoader extends TranslateLoader {
 const appRoutes: Routes = [
   { path: 'check', component: DomainComponent },
   { path: 'result/:resultID', component: ResultComponent },
-  { path: 'test/:resultID', component: ResultComponent },
   { path: 'history', component: HistoryComponent },
   { path: 'faq', component: FaqComponent },
 
   { path: 'domain_check', redirectTo: 'check', pathMatch: 'full' },
+  { path: 'test/:resultID', redirectTo: 'result/:resultID', pathMatch: 'full' },
   { path: '', redirectTo: 'check', pathMatch: 'full' },
 
   { path: '**', component: PageNotFoundComponent }

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -7,6 +7,7 @@ import {
   Validators,
   AbstractControl} from '@angular/forms';
 import { Title } from '@angular/platform-browser';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 
@@ -51,14 +52,27 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
   private _showProgressBar: boolean;
   private langChangeSubscription: Subscription;
 
+  private domainName: string;
+  private routeParamsSubscription: Subscription;
+
   public history = {};
   public test = {};
   public disable_check_button = false;
   public form: FormGroup;
 
-  constructor(private formBuilder: FormBuilder, private translateService: TranslateService, private titleService: Title) {}
+  constructor(private activatedRoute: ActivatedRoute,
+    private formBuilder: FormBuilder,
+    private translateService: TranslateService,
+    private titleService: Title) {}
 
   ngOnInit() {
+    this.routeParamsSubscription = this.activatedRoute.params.subscribe((params: Params) => {
+      if ( params['domain'] ) {
+        this.domainName = params['domain'];
+        console.log(this.domainName);
+      }
+    });
+
     this.langChangeSubscription = this.translateService.onLangChange.subscribe((_: LangChangeEvent) => {
       if (this.form.touched) {
         this.runDomainCheck(false);
@@ -76,6 +90,9 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnDestroy() {
     this.langChangeSubscription.unsubscribe();
+    if ( this.routeParamsSubscription ) {
+      this.routeParamsSubscription.unsubscribe();
+    }
   }
 
   private static atLeastOneProtocolValidator(control: AbstractControl) {

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -52,7 +52,6 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
   private _showProgressBar: boolean;
   private langChangeSubscription: Subscription;
 
-  private domainName: string = '';
   private routeParamsSubscription: Subscription;
 
   public history = {};
@@ -71,8 +70,8 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
 
     this.routeParamsSubscription = this.activatedRoute.params.subscribe((params: Params) => {
       if ( params['domain'] ) {
-        this.domainName = params['domain'];
-        this.form.controls.domain.setValue(this.domainName);
+        let domainName: string = params['domain'];
+        this.form.controls.domain.setValue(domainName);
         this.runDomainCheck();
       }
     });

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -69,7 +69,6 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
     this.routeParamsSubscription = this.activatedRoute.params.subscribe((params: Params) => {
       if ( params['domain'] ) {
         this.domainName = params['domain'];
-        console.log(this.domainName);
       }
     });
 
@@ -78,8 +77,13 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
         this.runDomainCheck(false);
       }
     });
+
     this.generate_form();
     this.titleService.setTitle('Zonemaster');
+
+    if ( this.domainName ) {
+        this.runDomainCheck();
+    }
   }
 
   ngOnChanges(changes: { [property: string]: SimpleChange }) {

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -66,9 +66,14 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
     private titleService: Title) {}
 
   ngOnInit() {
+    this.titleService.setTitle('Zonemaster');
+    this.generate_form();
+
     this.routeParamsSubscription = this.activatedRoute.params.subscribe((params: Params) => {
       if ( params['domain'] ) {
         this.domainName = params['domain'];
+        this.form.controls.domain.setValue(this.domainName);
+        this.runDomainCheck();
       }
     });
 
@@ -78,12 +83,6 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
       }
     });
 
-    this.generate_form();
-    this.titleService.setTitle('Zonemaster');
-
-    if ( this.domainName ) {
-        this.runDomainCheck();
-    }
   }
 
   ngOnChanges(changes: { [property: string]: SimpleChange }) {
@@ -94,9 +93,7 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnDestroy() {
     this.langChangeSubscription.unsubscribe();
-    if ( this.routeParamsSubscription ) {
-      this.routeParamsSubscription.unsubscribe();
-    }
+    this.routeParamsSubscription.unsubscribe();
   }
 
   private static atLeastOneProtocolValidator(control: AbstractControl) {
@@ -145,7 +142,7 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
 
   public generate_form() {
     this.form = new FormGroup({
-      domain: new FormControl(this.domainName, Validators.required),
+      domain: new FormControl('', Validators.required),
       disable_ipv4: new FormControl(false),
       disable_ipv6: new FormControl(false),
       profile: new FormControl(this.profiles[0] || 'default'),

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -52,7 +52,7 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
   private _showProgressBar: boolean;
   private langChangeSubscription: Subscription;
 
-  private domainName: string;
+  private domainName: string = '';
   private routeParamsSubscription: Subscription;
 
   public history = {};
@@ -141,7 +141,7 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
 
   public generate_form() {
     this.form = new FormGroup({
-      domain: new FormControl('', Validators.required),
+      domain: new FormControl(this.domainName, Validators.required),
       disable_ipv4: new FormControl(false),
       disable_ipv6: new FormControl(false),
       profile: new FormControl(this.profiles[0] || 'default'),

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -14,7 +14,7 @@
     <div [ngbCollapse]="!isNavbarCollapsed" class="collapse navbar-collapse" id="navBar">
       <ul class="navbar-nav mr-auto">
           <li class="nav-item">
-            <a class="nav-link" routerLink="/domain_check" routerLinkActive="active">{{'Domain check'|translate}} </a>
+            <a class="nav-link" routerLink="/check" routerLinkActive="active">{{'Domain check'|translate}} </a>
           </li>
           <li class="nav-item">
             <a class="nav-link" routerLink="/faq" routerLinkActive="active" >{{'FAQ'|translate}} </a>


### PR DESCRIPTION
## Purpose

It has been discussed to be able to easily pass a domain to test to Zonemaster GUI, without interacting with the form. The idea is to pass the domain name in the URL `/check/<domain>`.
The form's input field will be populated with this domain name and the form will be sent.

No option are currently passed. Only the domain. As I see it, we could extend this work to include options as GET parameters.

## Context

Addresses #200 and follow-up on #335

## Changes

* New route `/check/<domain>`
* Redirect `/domain_check` to `/check`
* Redirect `/test/<test-id>` to `/result/<test-id>`

## How to test this PR

* access `/check/<domain>` and make sure the test is started for \<domain\>
* once on the result page, go back to the previous page, the form should be sent again and the results page should be loaded
* e2e tests have been added to test both redirections
