### PR TITLE
Updated all FAQs

### DIFF
--- a/docs/FAQ/gui-faq-da.md
+++ b/docs/FAQ/gui-faq-da.md
@@ -68,8 +68,8 @@ advarsel. Den ekstra fordel ved værktøjet er, at man kan tilføje sin egen pol
 Zonemaster om at bruge denne politik til at afvikle tests.
 Men som alle andre ting udvikler DNS sig også, og det er sandsynligt, at en advarsel kan blive
 til en fejl på et senere tidspunkt. Hvis du mener, at Vi har lavet en fejl, så tøv ikke med at
-sende os en e-mail på adressen zonemaster-users@lists.iis.se (moderated mailing
-list) med et link til din test
+sende os en e-mail på adressen [zonemaster-users@lists.iis.se](mailto:zonemaster-users@lists.iis.se)
+(moderated mailing list) med et link til din test
 og en forklaring på, hvorfor du mener, at resultatet viser noget, som du anser forkert.
 
 <a name="q6"></a>

--- a/docs/FAQ/gui-faq-da.md
+++ b/docs/FAQ/gui-faq-da.md
@@ -68,7 +68,8 @@ advarsel. Den ekstra fordel ved værktøjet er, at man kan tilføje sin egen pol
 Zonemaster om at bruge denne politik til at afvikle tests.
 Men som alle andre ting udvikler DNS sig også, og det er sandsynligt, at en advarsel kan blive
 til en fejl på et senere tidspunkt. Hvis du mener, at Vi har lavet en fejl, så tøv ikke med at
-sende os en e-mail på adressen zonemaster-devel@lists.iis.se med et link til din test
+sende os en e-mail på adressen zonemaster-users@lists.iis.se (moderated mailing
+list) med et link til din test
 og en forklaring på, hvorfor du mener, at resultatet viser noget, som du anser forkert.
 
 <a name="q6"></a>

--- a/docs/FAQ/gui-faq-en.md
+++ b/docs/FAQ/gui-faq-en.md
@@ -77,7 +77,8 @@ file when running the tests.
 But as with all things as evolving as DNS the situation is most likely
 changing, what is a notice today could be an error tomorrow. If you really think
 we have made a mistake in our judgement please do not hesitate to drop us an email
-at zonemaster-devel@lists.iis.se with a link to your test and an explanation why you think it
+at zonemaster-users@lists.iis.se (moderated mailing list) with a link to your
+test and an explanation why you think it
 shows something that you consider incorrect.
 
 <a name="q6"></a>

--- a/docs/FAQ/gui-faq-en.md
+++ b/docs/FAQ/gui-faq-en.md
@@ -77,8 +77,8 @@ file when running the tests.
 But as with all things as evolving as DNS the situation is most likely
 changing, what is a notice today could be an error tomorrow. If you really think
 we have made a mistake in our judgement please do not hesitate to drop us an email
-at zonemaster-users@lists.iis.se (moderated mailing list) with a link to your
-test and an explanation why you think it
+at [zonemaster-users@lists.iis.se](mailto:zonemaster-users@lists.iis.se) (moderated
+mailing list) with a link to your test and an explanation why you think it
 shows something that you consider incorrect.
 
 <a name="q6"></a>

--- a/docs/FAQ/gui-faq-es.md
+++ b/docs/FAQ/gui-faq-es.md
@@ -79,8 +79,8 @@ Pero tal como muchas cosas que evolucionan como el DNS, la situación es
 cambiante en el tiempo, y lo que es un aviso hoy puede ser un error
 mañana. Si realmente crees que hemos cometido un error en nuestro
 juicio, por favor no dudes en enviarnos un email a 
-zonemaster-users@lists.iis.se (lista de correo moderada) con un enlace a tu
-prueba y una explicación
+[zonemaster-users@lists.iis.se](mailto:zonemaster-users@lists.iis.se)
+(lista de correo moderada) con un enlace a tu prueba y una explicación
 por qué crees que muestra algo que consideres incorrecto.
 
 <a name="q6"></a>

--- a/docs/FAQ/gui-faq-es.md
+++ b/docs/FAQ/gui-faq-es.md
@@ -79,7 +79,8 @@ Pero tal como muchas cosas que evolucionan como el DNS, la situación es
 cambiante en el tiempo, y lo que es un aviso hoy puede ser un error
 mañana. Si realmente crees que hemos cometido un error en nuestro
 juicio, por favor no dudes en enviarnos un email a 
-zonemaster-devel@lists.iis.se con un enlace a tu prueba y una explicación
+zonemaster-users@lists.iis.se (moderated mailing list) con un enlace a tu prueba
+y una explicación
 por qué crees que muestra algo que consideres incorrecto.
 
 <a name="q6"></a>

--- a/docs/FAQ/gui-faq-es.md
+++ b/docs/FAQ/gui-faq-es.md
@@ -79,8 +79,8 @@ Pero tal como muchas cosas que evolucionan como el DNS, la situación es
 cambiante en el tiempo, y lo que es un aviso hoy puede ser un error
 mañana. Si realmente crees que hemos cometido un error en nuestro
 juicio, por favor no dudes en enviarnos un email a 
-zonemaster-users@lists.iis.se (moderated mailing list) con un enlace a tu prueba
-y una explicación
+zonemaster-users@lists.iis.se (lista de correo moderada) con un enlace a tu
+prueba y una explicación
 por qué crees que muestra algo que consideres incorrecto.
 
 <a name="q6"></a>

--- a/docs/FAQ/gui-faq-fi.md
+++ b/docs/FAQ/gui-faq-fi.md
@@ -52,7 +52,7 @@ Kukaan ei voi antaa lopullista, kaikenkattavaa lausuntoa verkkotunnuksen kunnost
 
 Käyttäjänä voit helposti luoda oman profiilin, jonka avulla voit arvioida tiettyjen virheiden vakavuutta. Oman profiilin voi osoittaa suoraan CLI-työkalulla.
 
-Koska DNS kuitenkin kehittyy koko ajan, tilanteet, jotka ovat normaaleja nyt, saattavat olla tulevaisuudessa vakavia virheitä. Jos uskot löytäneesi jotakin, jonka olemme arvioineet väärin, ota epäröimättä yhteyttä osoitteeseen [zonemaster-devel@lists.iis.se](mailto:zonemaster-devel@lists.iis.se) ja lähetä linkki testiisi ja selitys siitä, miksi tulos ei ole mielestäsi oikein.
+Koska DNS kuitenkin kehittyy koko ajan, tilanteet, jotka ovat normaaleja nyt, saattavat olla tulevaisuudessa vakavia virheitä. Jos uskot löytäneesi jotakin, jonka olemme arvioineet väärin, ota epäröimättä yhteyttä osoitteeseen [zonemaster-users@lists.iis.se](mailto:zonemaster-users@lists.iis.se) (moderated mailing list) ja lähetä linkki testiisi ja selitys siitä, miksi tulos ei ole mielestäsi oikein.
 
 #### 6. Pystyykö Zonemaster käsittelemään IPv6:ta? <a name="q6"></a>
 

--- a/docs/FAQ/gui-faq-fr.md
+++ b/docs/FAQ/gui-faq-fr.md
@@ -95,8 +95,8 @@ Mais, avec les technonologies évolutives, comme le DNS, ce qui est aujourd'hui
 un simple avertissement, peut devenir demain une faille de sécurité grave. Si
 vous considérez que nous avons fait une erreur de jugement pour qualifier une
 erreur, n'hésitez pas à nous en faire part en envoyant un Email à l'adresse
-zonemaster-users@lists.iis.se (liste email modérée) avec le lien sur le test
-réalisé et un commentaire
+[zonemaster-users@lists.iis.se](mailto:zonemaster-users@lists.iis.se) (liste
+email modérée) avec le lien sur le test réalisé et un commentaire
 indiquant ce que vous pensez être incorrect dans notre diagnostique. (Si vous
 ne savez pas quel lien envoyer, consulter la réponse à la question "Qu'est-ce 
 que Zonemaster peut faire pour moi ?" qui se trouve dans cette FAQ)

--- a/docs/FAQ/gui-faq-fr.md
+++ b/docs/FAQ/gui-faq-fr.md
@@ -95,7 +95,8 @@ Mais, avec les technonologies évolutives, comme le DNS, ce qui est aujourd'hui
 un simple avertissement, peut devenir demain une faille de sécurité grave. Si
 vous considérez que nous avons fait une erreur de jugement pour qualifier une
 erreur, n'hésitez pas à nous en faire part en envoyant un Email à l'adresse
-zonemaster-devel@lists.iis.se avec le lien sur le test réalisé et un commentaire
+zonemaster-users@lists.iis.se (moderated mailing list) avec le lien sur le test
+réalisé et un commentaire
 indiquant ce que vous pensez être incorrect dans notre diagnostique. (Si vous
 ne savez pas quel lien envoyer, consulter la réponse à la question "Qu'est-ce 
 que Zonemaster peut faire pour moi ?" qui se trouve dans cette FAQ)

--- a/docs/FAQ/gui-faq-fr.md
+++ b/docs/FAQ/gui-faq-fr.md
@@ -95,7 +95,7 @@ Mais, avec les technonologies évolutives, comme le DNS, ce qui est aujourd'hui
 un simple avertissement, peut devenir demain une faille de sécurité grave. Si
 vous considérez que nous avons fait une erreur de jugement pour qualifier une
 erreur, n'hésitez pas à nous en faire part en envoyant un Email à l'adresse
-zonemaster-users@lists.iis.se (moderated mailing list) avec le lien sur le test
+zonemaster-users@lists.iis.se (liste email modérée) avec le lien sur le test
 réalisé et un commentaire
 indiquant ce que vous pensez être incorrect dans notre diagnostique. (Si vous
 ne savez pas quel lien envoyer, consulter la réponse à la question "Qu'est-ce 

--- a/docs/FAQ/gui-faq-nb.md
+++ b/docs/FAQ/gui-faq-nb.md
@@ -50,7 +50,7 @@ Det beror på hvilket test som gikk galt for domenet.
 #### 5. Hvordan avgjør Zonemaster hva som er rett eller feil? <a name="q5"></a>
 Det er viktig å understreke at ingen kan gi en endelig uttalelse om helsen til et domene. Zonemaster er ikke alltid fullstendig korrekt, og resultatene kan gi rom for tolkning. De som står bak testen understreker at de har gjort sitt aller beste for å utvikle en best mulig policy for vurdering av ulike feil før de blir presentert for deg som bruker verktøyet.
 
-Hvis du syns at et testresultat er feil så oppfordrer vi til å sende en e-post til zonemaster-users@lists.iis.se (moderert e-postliste) med en lenke til testresultatet og forklar hvorfor du synes testen er feil.
+Hvis du syns at et testresultat er feil så oppfordrer vi til å sende en e-post til [zonemaster-users@lists.iis.se](mailto:zonemaster-users@lists.iis.se) (moderert e-postliste) med en lenke til testresultatet og forklar hvorfor du synes testen er feil.
 
 #### 6. Håndterer Zonemaster IPv6? <a name="q6"></a>
 Ja, alle tester kjøres på både IPv4 og IPv6.

--- a/docs/FAQ/gui-faq-nb.md
+++ b/docs/FAQ/gui-faq-nb.md
@@ -50,7 +50,7 @@ Det beror på hvilket test som gikk galt for domenet.
 #### 5. Hvordan avgjør Zonemaster hva som er rett eller feil? <a name="q5"></a>
 Det er viktig å understreke at ingen kan gi en endelig uttalelse om helsen til et domene. Zonemaster er ikke alltid fullstendig korrekt, og resultatene kan gi rom for tolkning. De som står bak testen understreker at de har gjort sitt aller beste for å utvikle en best mulig policy for vurdering av ulike feil før de blir presentert for deg som bruker verktøyet.
 
-Hvis du syns at et testresultat er feil så oppfordrer vi til å sende en e-post til zonemaster-devel@lists.iis.se med en lenke til testresultatet og forklar hvorfor du synes testen er feil.
+Hvis du syns at et testresultat er feil så oppfordrer vi til å sende en e-posttil zonemaster-users@lists.iis.se (moderated mailing list) med en lenke til testresultatet og forklar hvorfor du synes testen er feil.
 
 #### 6. Håndterer Zonemaster IPv6? <a name="q6"></a>
 Ja, alle tester kjøres på både IPv4 og IPv6.

--- a/docs/FAQ/gui-faq-nb.md
+++ b/docs/FAQ/gui-faq-nb.md
@@ -50,7 +50,7 @@ Det beror på hvilket test som gikk galt for domenet.
 #### 5. Hvordan avgjør Zonemaster hva som er rett eller feil? <a name="q5"></a>
 Det er viktig å understreke at ingen kan gi en endelig uttalelse om helsen til et domene. Zonemaster er ikke alltid fullstendig korrekt, og resultatene kan gi rom for tolkning. De som står bak testen understreker at de har gjort sitt aller beste for å utvikle en best mulig policy for vurdering av ulike feil før de blir presentert for deg som bruker verktøyet.
 
-Hvis du syns at et testresultat er feil så oppfordrer vi til å sende en e-posttil zonemaster-users@lists.iis.se (moderated mailing list) med en lenke til testresultatet og forklar hvorfor du synes testen er feil.
+Hvis du syns at et testresultat er feil så oppfordrer vi til å sende en e-post til zonemaster-users@lists.iis.se (moderert e-postliste) med en lenke til testresultatet og forklar hvorfor du synes testen er feil.
 
 #### 6. Håndterer Zonemaster IPv6? <a name="q6"></a>
 Ja, alle tester kjøres på både IPv4 og IPv6.

--- a/docs/FAQ/gui-faq-sv.md
+++ b/docs/FAQ/gui-faq-sv.md
@@ -68,7 +68,8 @@ allvarliga vissa fel ska vara, via CLI-verktyget går det att direkt peka ut sin
 
 Men eftersom DNS utvecklas hela tiden kan situationer som idag bara kräver en 
 varning räknas som allvarliga fel imorgon. Om du tror du hittat något som du tycker
-vi felbedömt, tveka då inte att kontakta oss på zonemaster-devel@lists.iis.se med en 
+vi felbedömt, tveka då inte att kontakta oss på zonemaster-users@lists.iis.se
+(modererad e-postlista) med en
 länk till ditt test och en förklaring av varför du anser att resultatet inte är
 korrekt. 
 

--- a/docs/FAQ/gui-faq-sv.md
+++ b/docs/FAQ/gui-faq-sv.md
@@ -68,10 +68,10 @@ allvarliga vissa fel ska vara, via CLI-verktyget går det att direkt peka ut sin
 
 Men eftersom DNS utvecklas hela tiden kan situationer som idag bara kräver en 
 varning räknas som allvarliga fel imorgon. Om du tror du hittat något som du tycker
-vi felbedömt, tveka då inte att kontakta oss på zonemaster-users@lists.iis.se
-(modererad e-postlista) med en
-länk till ditt test och en förklaring av varför du anser att resultatet inte är
-korrekt. 
+vi felbedömt, tveka då inte att kontakta oss på
+[zonemaster-users@lists.iis.se](mailto:zonemaster-users@lists.iis.se) (modererad
+e-postlista) med en länk till ditt test och en förklaring av varför du anser att
+resultatet inte är korrekt.
 
 <a name="q6"></a>
 #### 6. Kan Zonemaster hantera IPv6?


### PR DESCRIPTION
## Purpose

FAQ 5 has the old mailing list address.

* Updated (corrected) mail address to mailing list.
* Added a comment that it is in fact a mailing list.

After the address I added "(moderated mailing list)" so that the send should know that. For Swedish I inserted a translated version, but for all other languages (da, es, fi, fr and nb) I inserted the same English text. Please add the correct wording for "your" language as a review comment to this PR.

2022-09-20: Turned the mail address into a mailto link, unless it already was.

## Context

On all, or most, installations of the GUI the wrong mail address is shown, and that results in an error.

## How to test this PR

Review the text.