### PR TITLE
Use a drop down menu to select between languages

### DIFF
--- a/e2e/FR05.e2e-spec.ts
+++ b/e2e/FR05.e2e-spec.ts
@@ -18,16 +18,16 @@ test.describe('Zonemaster test FR05 - [Supports internationalization]', () => {
   ];
 
   for (const { language, code, expected } of testSuite) {
-    test(`should have ${language} language button`, async ({ page }) => {
-      const langNavLink = page.locator(`.lang > div > a[lang="${code}"]`);
+    test(`should have ${language} language option`, async ({ page }) => {
+      const langNavLink = page.locator(`select#languageSelection > option[lang="${code}"]`);
       await expect(langNavLink).toHaveCount(1);
     })
 
-    test(`should switch switch to ${language}`, async ({ page }) => {
+    test(`should switch to ${language}`, async ({ page }) => {
       await setLang(page, code);
       await expect(page.locator('h1')).toHaveText(expected);
 
-      const langNavLink = page.locator(`.lang > div > a[lang="${code}"]`);
+      const langNavLink = page.locator(`select#languageSelection > option[lang="${code}"]`);
       await expect(langNavLink).toHaveCount(1);
       await expect(langNavLink).toHaveAttribute('lang', code);
     })

--- a/e2e/utils/app.utils.ts
+++ b/e2e/utils/app.utils.ts
@@ -4,8 +4,8 @@ export function goToHome(page) {
 
 export function setLang(page, lang) {
   return Promise.all([
-    page.waitForSelector(`.lang > div > a.selected[lang="${lang}"]`),
-    page.locator(`.lang > div > a[lang="${lang}"]`).click(),
+    page.waitForSelector('select#languageSelection'),
+    page.locator('select#languageSelection').selectOption(lang),
   ]);
 }
 

--- a/src/app/components/navigation/navigation.component.css
+++ b/src/app/components/navigation/navigation.component.css
@@ -17,9 +17,15 @@ nav {
 .navbar-brand div {
   height: 100%;
 }
-.lang > div > a {
-  cursor: pointer;
-  color: inherit;
+.lang {
+  display: inline-flex;
+  align-items: center;
+}
+.lang .icon {
+  width: 27px;
+  line-height: 27px;
+  margin: 0 5px;
+  font-size: 20pt;
 }
 #languageSelection{
   width: auto;
@@ -47,6 +53,10 @@ nav {
 
   nav {
     height: auto;
+  }
+
+  .lang .icon {
+    display: none;
   }
 }
 

--- a/src/app/components/navigation/navigation.component.css
+++ b/src/app/components/navigation/navigation.component.css
@@ -21,16 +21,9 @@ nav {
   cursor: pointer;
   color: inherit;
 }
-
-.lang > div > a.selected {
-  font-weight: bold;
-  text-decoration: underline solid 1px;
+#languageSelection{
+  width: auto;
 }
-
-.lang > div > a {
-  text-decoration: none;
-}
-
 .github {
   height: 100%;
 }

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -22,6 +22,7 @@
       </ul>
 
       <div class="lang">
+        <span class="icon"><i class="fa fa-language" aria-hidden="true"></i></span>
         <div class="d-block">
           <select name="lang" [(ngModel)]="lang" (change)="setLanguage(lang)" class="form-select" id="languageSelection">
             <option *ngFor="let itemLang of enabledLanguages" [lang]="itemLang" [value]="itemLang" [selected]="lang === itemLang">

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -21,8 +21,11 @@
         </li>
       </ul>
 
-      <div class="lang">
-        <span class="icon"><i class="fa fa-language" aria-hidden="true"></i></span>
+      <div class="lang" i18n-title title="Change language">
+        <label for="languageSelection" class="icon">
+            <i class="fa fa-language" aria-hidden="true"></i>
+            <span class="sr-only" i18n>Change language</span>
+        </label>
         <div class="d-block">
           <select name="lang" [(ngModel)]="lang" (change)="setLanguage(lang)" class="form-select" id="languageSelection">
             <option *ngFor="let itemLang of enabledLanguages" [lang]="itemLang" [value]="itemLang" [selected]="lang === itemLang">

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -22,15 +22,8 @@
       </ul>
 
       <div class="lang">
-        <div class="d-none d-sm-block">
-          <ng-container  *ngFor="let itemLang of enabledLanguages; let i = index">
-            <a [lang]="itemLang" (click)="setLanguage(itemLang)" [title]="languages[itemLang]" [class.selected]="lang===itemLang">{{ itemLang | titlecase }}</a>
-            <ng-container *ngIf="i < enabledLanguages.length - 1; else endLangNav"> | </ng-container>
-          </ng-container>
-          <ng-template #endLangNav> &nbsp; </ng-template>
-        </div>
-        <div class="d-sm-none">
-          <select name="lang" [(ngModel)]="lang" (change)="setLanguage(lang)" class="form-control" id="languageSelection">
+        <div class="d-block">
+          <select name="lang" [(ngModel)]="lang" (change)="setLanguage(lang)" class="form-select" id="languageSelection">
             <option *ngFor="let itemLang of enabledLanguages" [lang]="itemLang" [value]="itemLang" [selected]="lang === itemLang">
               {{ languages[itemLang] }}
             </option>


### PR DESCRIPTION
## Purpose

Zonemaster supports more and more languages, and the GUI displays all of them on a row. This could lead to eating a lot of space. This PR replaces this row with a drop down menu (a \<select\> element) with an icon representing language selection (icon from [fork awesome](https://forkaweso.me/Fork-Awesome/icon/language/)).

![image](https://user-images.githubusercontent.com/70589067/189942124-bf79a364-0306-432f-9a00-f94e0ff41cfb.png)

## Context

Addresses a comment made when discussing the possibility to provide a new page for the "History" (PR #333) where it was pointed out that in some locale, the menu will span a lot of available space (almost eating on the language selection space).

## Changes

Remove the horizontal language list in the header.

## How to test this PR

Use the new drop down language selection menu to switch across languages. The page should be updated accordingly.