### PR TITLE
Better keyboard navigation

### DIFF
--- a/src/app/components/form/form.component.css
+++ b/src/app/components/form/form.component.css
@@ -1,24 +1,8 @@
-.fa-play-circle-o:hover {
-  color: #fff;
-}
-
-.fa-play-circle-o {
-  color: #9ad;
-}
-
 #domain_check_name {
   font-size:16px;
   height:64px;
   color:#6F787E;
   border-radius:3px
-}
-
-.checkboxForm {
-  width: 100%;
-}
-
-.half-with {
-  width: 50%;
 }
 
 button.launch {
@@ -29,63 +13,40 @@ button.launch:hover {
   background-color: #ff3c3a;
 }
 
+.advanced-options {
+  margin-top: 1em;
+}
 /* The switch - the box around the slider */
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 60px;
-  height: 34px;
+.switch-input-container {
+  display: flex;
+  align-items: center;
 }
 
-/* Hide default HTML checkbox */
-.switch input {display:none;}
+.switch-input-container label {
+  margin: 0;
+}
 
-/* The slider */
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+input[type=checkbox].switch-input {
+  width: 2em;
   background-color: #ccc;
-  -webkit-transition: .4s;
-  transition: .4s;
+  display: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  height: 1em;
+  border-radius: 2em;
+  font-size: 2em;
+  background-repeat: no-repeat;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e");
+  background-position: left center;
+  transition: all .25s ease-in-out;
+  margin-right: 0.2em;
+  cursor: pointer;
 }
 
-.slider:before {
-  position: absolute;
-  content: "";
-  height: 26px;
-  width: 26px;
-  left: 4px;
-  bottom: 4px;
-  background-color: white;
-  -webkit-transition: .4s;
-  transition: .4s;
-}
-
-.advanced input:checked + .slider {
-  background-color: #2196F3;
-}
-
-.advanced input:focus + .slider {
-  box-shadow: 0 0 1px #2196F3;
-}
-
-.advanced input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
-}
-
-/* Rounded sliders */
-.slider.round {
-  border-radius: 34px;
-}
-
-.slider.round:before {
-  border-radius: 50%;
+input[type=checkbox].switch-input:checked {
+  background-position: right center;
+  background-color: #2196f3;
 }
 
 .advanced {

--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -52,15 +52,13 @@
     </div>
     <div class="row">
       <div class="advanced col-sm-10 offset-sm-1">
-        <label class="d-flex" for="advanced_checkbox">
-          <span class="switch">
-            <input type="checkbox" name="advanced_checkbox" id="advanced_checkbox" (change)="toggleOptions()" [ngModel]="is_advanced_options_enabled" [ngModelOptions]="{standalone: true}">
-            <span class="slider round"></span>
-          </span>
-          <p class="ml-1 pt-1">{{'Options'|translate}}</p>
-        </label>
 
-        <div *ngIf="is_advanced_options_enabled">
+        <div class="switch-input-container">
+          <input class="switch-input" type="checkbox" id="advanced_checkbox" (change)="toggleOptions()" [ngModel]="is_advanced_options_enabled" [ngModelOptions]="{standalone: true}">
+          <label for="advanced_checkbox">{{'Options'|translate}}</label>
+        </div>
+
+        <div *ngIf="is_advanced_options_enabled" class="advanced-options">
           <div class="form-row protocol-form">
             <div class="col-md-10">
               <div [class.is-invalid]="form.errors?.noProtocol">
@@ -228,8 +226,11 @@
 
           <br>
 
-          <button type="button" class="btn btn-secondary fetchDataFromParent" (click)="displayDataFromParent()">{{'Fetch data from parent zone'|translate}}</button>
-          <button type="button" class="btn btn-danger resetFullForm" (click)="resetFullForm()">{{'Reset'|translate}}</button>
+          <button type="button" class="btn btn-secondary fetchDataFromParent" (click)="displayDataFromParent()">
+            {{'Fetch data from parent zone'|translate}}
+          </button>&nbsp;<button type="button" class="btn btn-danger resetFullForm" (click)="resetFullForm()">
+            {{'Reset'|translate}}
+          </button>
 
         </div>
       </div>

--- a/src/app/components/history/history.component.html
+++ b/src/app/components/history/history.component.html
@@ -1,36 +1,27 @@
 <div class="container-fluid">
   <div class="row mb-2">
-    <div class="btn-group btn-group-toggle">
-      <label class="btn btn-secondary" for="filter_all" [class.active]="filter === 'all'">
-        <input type="radio"
-               [ngModel]="filter"
-               value="all"
-               name="options"
-               id="filter_all"
-               (ngModelChange)="filterHistory($event)"
-               autocomplete="off">
+    <div class="btn-group" role="group">
+      <button
+        type="button"
+        class="btn btn-secondary"
+        [class.active]="filter === 'all'"
+        (click)="filterHistory('all')">
         {{ 'All' | translate }}
-      </label>
-      <label class="btn btn-secondary"for="filter_delegated" [class.active]="filter === 'delegated'">
-        <input type="radio"
-               [ngModel]="filter"
-               value="delegated"
-               name="filter"
-               id="filter_delegated"
-               (ngModelChange)="filterHistory($event)"
-               autocomplete="off">
+      </button>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        [class.active]="filter === 'delegated'"
+        (click)="filterHistory('delegated')">
         {{ 'DELEGATED_PLURAL' | translate }}
-      </label>
-      <label class="btn btn-secondary" for="filter_undelegated" [class.active]="filter === 'undelegated'">
-        <input type="radio"
-               [ngModel]="filter"
-               value="undelegated"
-               name="filter"
-               id="filter_undelegated"
-               (ngModelChange)="filterHistory($event)"
-               autocomplete="off">
+      </button>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        [class.active]="filter === 'undelegated'"
+        (click)="filterHistory('undelegated')">
         {{ 'UNDELEGATED_PLURAL' | translate }}
-      </label>
+      </button>
     </div>
   </div>
 

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -12,14 +12,14 @@
     </div>
     <div class="actions-btn">
       <div>
-        <a class="btn btn-secondary history" (click)="getHistory()">
+        <button class="btn btn-secondary history" (click)="getHistory()" tabindex="0">
           <i class="fa fa-history text-white" aria-hidden="true"></i>
           <span class="text-white">{{'History'|translate}}</span>
-        </a>
+        </button>
 
         <div ngbDropdown placement="bottom-center" class="d-inline-block">
           <button class="btn btn-secondary export" id="shareDropdownResult" ngbDropdownToggle>
-            <i class="fa fa-cloud-download text-white"></i>
+            <i class="fa fa-cloud-download text-white" aria-hidden="true"></i>
             <span class="text-white">{{'Export'|translate}}</span>
           </button>
           <div ngbDropdownMenu aria-labelledby="shareDropdownResult">
@@ -58,7 +58,8 @@
         <a placement="top" [ngbTooltip]="tooltipAll"
            class="nav-link" [ngClass]="{'active all text-white': result_filter.all}"
            (click)="togglePillFilter('all')"
-           [(ngModel)]="result_filter.all" ngDefaultControl>
+           (keydown)="onFilterLevelKeyDownEvent($event, 'all')"
+           [(ngModel)]="result_filter.all" tabindex="0" ngDefaultControl>
           All <span class="badge badge-pill badge-secondary">{{result.length}}</span></a>
       </li>
       <li class="nav-item ml-1">
@@ -66,7 +67,8 @@
         <a placement="top" [ngbTooltip]="tooltipInfo"
            class="nav-link" [ngClass]="{'active info text-white': result_filter.info}"
            (click)="togglePillFilter('info')"
-           [(ngModel)]="result_filter.info" ngDefaultControl>
+           (keydown)="onFilterLevelKeyDownEvent($event, 'info')"
+           [(ngModel)]="result_filter.info" tabindex="0" ngDefaultControl>
           Info
           <span class="badge badge-pill badge-secondary">{{level_items['info'].length}}</span></a>
       </li>
@@ -75,7 +77,8 @@
         <a placement="top" [ngbTooltip]="tooltipNotice"
            class="nav-link" [ngClass]="{'active notice text-white': result_filter.notice}"
            (click)="togglePillFilter('notice')"
-           [(ngModel)]="result_filter.notice" ngDefaultControl>
+           (keydown)="onFilterLevelKeyDownEvent($event, 'notice')"
+           [(ngModel)]="result_filter.notice" tabindex="0" ngDefaultControl>
           Notice <span class="badge badge-pill badge-secondary">{{level_items['notice'].length}}</span></a>
       </li>
       <li class="nav-item ml-1">
@@ -83,7 +86,8 @@
         <a placement="top" [ngbTooltip]="tooltipWarning"
            class="nav-link" [ngClass]="{'active warning text-white': result_filter.warning}"
            (click)="togglePillFilter('warning')"
-           [(ngModel)]="result_filter.warning" ngDefaultControl>
+           (keydown)="onFilterLevelKeyDownEvent($event, 'warning')"
+           [(ngModel)]="result_filter.warning"  tabindex="0" ngDefaultControl>
           Warning <span class="badge badge-pill badge-secondary">{{level_items['warning'].length}}</span></a>
       </li>
       <li class="nav-item ml-1">
@@ -91,7 +95,8 @@
         <a placement="top" [ngbTooltip]="tooltipError"
            class="nav-link" [ngClass]="{'active error text-white': result_filter.error}"
            (click)="togglePillFilter('error')"
-           [(ngModel)]="result_filter.error" ngDefaultControl>
+           (keydown)="onFilterLevelKeyDownEvent($event, 'error')"
+           [(ngModel)]="result_filter.error" tabindex="0" ngDefaultControl>
           Error <span class="badge badge-pill badge-secondary">{{level_items['error'].length}}</span></a>
       </li>
       <li class="nav-item ml-1">
@@ -99,7 +104,8 @@
         <a placement="top" [ngbTooltip]="tooltipCritical"
            class="nav-link" [ngClass]="{'active critical text-white': result_filter.critical}"
            (click)="togglePillFilter('critical')"
-           [(ngModel)]="result_filter.critical" ngDefaultControl>
+           (keydown)="onFilterLevelKeyDownEvent($event, 'critical')"
+           [(ngModel)]="result_filter.critical" tabindex="0" ngDefaultControl>
           Critical <span class="badge badge-pill badge-secondary">{{level_items['critical'].length}}</span></a>
       </li>
     </ul>
@@ -115,14 +121,14 @@
 
   <div class="mt-3">
     <section *ngFor="let moduleKey of modulesKeys | filter : result_filter['search']:true:module_items | filterByCategories:result_filter:searchQueryLength:'level':true:module_items" [class.expanded]="!isCollapsed[moduleKey]">
-      <a [attr.aria-controls]="'module-' + moduleKey" [attr.aria-expanded]="!isCollapsed[moduleKey]">
-        <h3 (click)="isCollapsed[moduleKey] = !isCollapsed[moduleKey]" class="{{modules[moduleKey]}} {{moduleKey}}" [ngStyle]="{'top': (navHeight + 7) + 'px'}" #headerRef>
+      <a [attr.aria-controls]="'module-' + moduleKey" [attr.aria-expanded]="!isCollapsed[moduleKey]" (click)="isCollapsed[moduleKey] = !isCollapsed[moduleKey]" (keydown)="onModuleKeyDownEvent($event, moduleKey)">
+        <h3 class="{{modules[moduleKey]}} {{moduleKey}}" [ngStyle]="{'top': (navHeight + 7) + 'px'}" #headerRef>
           <i class="fa" placement="top" ngbTooltip="{{(isCollapsed[moduleKey] ? 'Expand': 'Collapse')}}" [ngClass]="{'fa-plus': isCollapsed[moduleKey],'fa-minus': !isCollapsed[moduleKey]}" aria-hidden="true"></i>
-          <span>{{moduleKey}}</span>
+          <span tabindex="0">{{moduleKey}}</span>
         </h3>
       </a>
-      <div id="module-{{moduleKey}}" [ngbCollapse]="isCollapsed[moduleKey]" (hidden)="moduleCollapsed(headerRef)" [animation]="false">
-        <div *ngFor="let item of module_items[moduleKey] | filter : result_filter['search'] | filterByCategories : result_filter:searchQueryLength:'level'; let i = index" class="entry {{item.level}}">
+      <div role="list" id="module-{{moduleKey}}" [ngbCollapse]="isCollapsed[moduleKey]" (hidden)="moduleCollapsed(headerRef)" [animation]="false">
+        <div role="listitem" *ngFor="let item of module_items[moduleKey] | filter : result_filter['search'] | filterByCategories : result_filter:searchQueryLength:'level'; let i = index" class="entry {{item.level}}">
           <div class="module-name">{{item.module|translate}}</div>
           <div class="severity">{{item.level}}</div>
           <p class="message">{{item.message|translate}}</p>
@@ -133,12 +139,12 @@
 </div>
 
 <ng-template #historyModal let-c="close" let-d="dismiss">
-  <div class="modal-header">
-  <h4 class="modal-title">{{'History'|translate}}</h4>
+  <header class="modal-header">
+    <h4 class="modal-title">{{'History'|translate}}</h4>
     <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
       <span aria-hidden="true">&times;</span>
     </button>
-  </div>
+  </header>
   <div class="modal-body">
     <app-history [history]="history"></app-history>
   </div>

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -116,6 +116,22 @@ export class ResultComponent implements OnInit, OnDestroy {
     });
   }
 
+  public onModuleKeyDownEvent(event, moduleKey) {
+    switch (event.key) {
+      case 'Enter':
+        this.isCollapsed[moduleKey] = !this.isCollapsed[moduleKey];
+        break;
+    }
+  }
+
+  public onFilterLevelKeyDownEvent(event, level) {
+    switch (event.key) {
+      case 'Enter':
+        this.togglePillFilter(level);
+        break;
+    }
+  }
+
   public moduleCollapsed(headerRef) {
     let headerRect = headerRef.getBoundingClientRect();
 


### PR DESCRIPTION
## Purpose

Some elements on the "run test" page and "result" page were not focusable or if they were not actionable.
This PR tries to improve overall keyboard accessibility.

## Context

n/a

## Changes

Full keyboard navigation is now possible across all pages.
* Advanced option switches is now a styled checkbox and behave as one.
* Make the module "boxes" in the results focusable and expandable when Enter key is pressed.
* Log level filtering can be toggled using keyboard.
* The history button is now a actual button and not a link.
* Filter buttons in history modal are now button and not a broken radio input anymore.
* Some css cleanup.

## How to test this PR

Try to use the gui without a mouse.