### PR TITLE
Force footer to the viewport's bottom

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,5 @@
+:host {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,8 @@
 <app-navigation></app-navigation>
 <app-alert></app-alert>
-<router-outlet></router-outlet>
+<main>
+  <router-outlet></router-outlet>
+</main>
 <app-footer></app-footer>
 
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,10 @@ html, body {
   padding:0;
 }
 
+main {
+  flex-grow: 2;
+}
+
 .main h1 {
   margin: 0;
   text-shadow: 2px 2px 3px rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
## Purpose

Currently the footer part of the GUI might lay in the middle of the page. Especially if the screen resolution is too high and all the content fits on the page. This provides some CSS rules to make the inner content grow and push the footer to the bottom of the viewport.

## Context

n/a

## Changes

CSS files

## How to test this PR

Run the GUI using this branch and check that the footer is always pushed to the bottom of the viewport, regardless of the screen size/resolution.
