### PR TITLE
Fix notifications behaviour

### DIFF
--- a/src/app/components/alert/alert.component.css
+++ b/src/app/components/alert/alert.component.css
@@ -1,8 +1,14 @@
 .alert-area {
   z-index: 999;
   position: absolute;
-  margin-top: 20px;
+  margin-top: 80px;
   max-width: inherit;
   width: 100%;
+  padding-top: 20px;
 }
 
+:host {
+  position: sticky;
+  top: 0;
+  z-index: 1020;
+}

--- a/src/app/components/alert/alert.component.html
+++ b/src/app/components/alert/alert.component.html
@@ -1,5 +1,5 @@
-<div class="container" [ngClass]="{'sticky-top': isShrunk}" >
-  <div class="row alert-area">
+<div class="container">
+  <div class="row alert-area" [ngStyle]="{'margin-top': navHeight + 'px'}">
     <div *ngFor="let alert of alerts" class="{{ cssClass(alert) }} alert-dismissible" role="alert">
       {{alert.message}}
       <button type="button" class="btn-close" (click)="removeAlert(alert)" i18n-title title="Close" i18n-aria-label aria-label="Close"></button>

--- a/src/app/components/alert/alert.component.ts
+++ b/src/app/components/alert/alert.component.ts
@@ -1,28 +1,26 @@
-import { Component, OnInit, NgZone} from '@angular/core';
+import { Component, OnInit, OnDestroy} from '@angular/core';
+import { Subscription } from 'rxjs';
 
 import { Alert, AlertType } from '../../models/index';
 import { AlertService } from '../../services/alert.service';
+import { NavigationService } from '../../services/navigation.service';
 
 @Component({
   selector: 'app-alert',
   templateUrl: './alert.component.html',
   styleUrls: ['./alert.component.css']
 })
-export class AlertComponent implements OnInit {
+export class AlertComponent implements OnInit, OnDestroy {
 
   alerts: Alert[] = [];
-  public isShrunk = false;
+  public navHeight: number;
+  private navHeightSubscription: Subscription;
 
-  constructor(private alertService: AlertService, zone: NgZone) {
-    window.onscroll = () => {
-      zone.run(() => {
-        if (window.pageYOffset > 1) {
-          this.isShrunk = true;
-        } else {
-          this.isShrunk = false;
-        }
-      });
-    };
+  constructor(
+    private alertService: AlertService,
+    private navigationService: NavigationService
+  ) {
+
   }
 
   ngOnInit() {
@@ -36,6 +34,14 @@ export class AlertComponent implements OnInit {
 
       setTimeout(() => this.removeAlert(alert), 5000);
     });
+
+    this.navHeightSubscription = this.navigationService.height.subscribe((newHeight: number) => {
+      this.navHeight = newHeight;
+    });
+  }
+
+  ngOnDestroy() {
+    this.navHeightSubscription.unsubscribe();
   }
 
   removeAlert(alert: Alert) {

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -80,16 +80,9 @@ export class ResultComponent implements OnInit, OnDestroy {
 
     let data = this.router.getCurrentNavigation().extras.state || {};
     this.displayForm = data.displayForm === undefined ? false : data.displayForm;
-
-    // When redirected from the domain check page we display the notification here as the other component has been destroyed
-    if (this.displayForm) {
-      this.alertService.success($localize `Test completed`);
-    }
   }
 
   ngOnInit() {
-    console.log(this.testId);
-
     this.routeParamsSubscription = this.activatedRoute.params.subscribe((params: Params) => {
       this.testId = params['testId'];
       this.fetchResult(this.testId);

--- a/src/app/components/run-test/run-test.component.ts
+++ b/src/app/components/run-test/run-test.component.ts
@@ -74,7 +74,7 @@ export class RunTestComponent implements OnInit {
 
           if (self.runTestProgression === 100) {
             clearInterval(handle);
-            this.alertService.success($localize `Test completed`);
+            this.alertService.success($localize `Test completed`, true);
             self.testId = testId;
             self.isAdvancedOptionEnabled = false;
             self.showResult = true;


### PR DESCRIPTION
## Purpose

Fix notifications behaviour.

## Context

* The notifications were displayed behind the navigation bar. (introduced in #365, spotted in https://github.com/zonemaster/zonemaster-gui/pull/364#pullrequestreview-1197123148)
* Success notifications were not displayed when the test was started from the result page (introduced in #257 / #300)

## Changes

* Fix the alert container position to always be below the navigation bar.
* Always display the success notification after when the test succeed

## How to test this PR

Position
* Try fetching data for a non existing domain.
* Check that the notification is displayed.
* Try to scroll, the notification should be sticky below the navigation bar.

Notification not always displayed
* Create a test from the result page for a different domain
* Check that the success notification is displayed