### PR TITLE
Deduplicate the assets directory

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -323,7 +323,7 @@ from wich the GUI is served.
 
 
 **NOTE:** Don't forget to apply the changes to the `index.html` and Web
-server configurartion after each updates as thoses files will be overwritten.
+server configuration after each updates as thoses files will be overwritten.
 
 
 ## Change default language

--- a/scripts/create_release.js
+++ b/scripts/create_release.js
@@ -19,6 +19,12 @@ archive.pipe(output);
 
 archive.file('zonemaster.conf-example', { name: 'zonemaster.conf-example' });
 archive.file('LICENSE', { name: 'LICENSE' });
-archive.directory('dist/', 'dist');
+
+const localizedBundles = fs.readdirSync('dist', {withFileTypes: true})
+  .filter(entry => entry.isDirectory())
+  .map(entry => entry.name);
+
+archive.glob('dist/**', {ignore: '**/assets/**'});
+archive.directory(`dist/${localizedBundles[0]}/assets`, 'dist/assets');
 
 archive.finalize();

--- a/zonemaster.conf-example
+++ b/zonemaster.conf-example
@@ -21,6 +21,9 @@
     RewriteBase ${BASE_URL}
     RewriteRule ^../index\.html$ - [L]
 
+    # Rewrite /<LANG>/assets/ to /assets to share the assets directory
+    RewriteRule ^../(assets/.+) $1 [L]
+
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule (..) $1/index.html [L]


### PR DESCRIPTION
## Purpose

Since the migration to @angular/localize one bundle is generated per locale. This duplicates the assets.

While for the images it is sub-optimal but acceptable, for the configuration it is not. A user should not be required to update 6 times (or more in the future) the configuration, it is unpractical and error prone.

This PR changes the way the release zip is built to only use one assets folder. The asset folder is colocated with the locales folder to form the following architecture.

```
└── dist
    ├── assets
    │   ├── css
    │   ├── faqs
    │   ├── favicon
    │   └── images
    ├── da
    ├── en
    ├── es
    ├── fi
    ├── fr
    ├── nb
    └── sv
```

This way the assets folder is only present once. Also it means that our previous documentation still applies as the configuration path as not changed. Users will not have to move/copy the configuration file else where and will be able to reuse the existing one.

## Context

#374 

## Changes

* Use only one asset directory for all locales.
* Correct a typo in documentation

## How to test this PR

* Deploy the GUI using the release zip and apache configuration.
* Images (ZM logo) should be displayed and configuration should be accessible (try setting a message banner for instance).
* FAQ should be accessible.
