### PR TITLE
Redirect deprecated path

### DIFF
--- a/zonemaster.conf-example
+++ b/zonemaster.conf-example
@@ -29,26 +29,8 @@
     RewriteRule (..) $1/index.html [L]
 
     # Redirect user based on prefered locale
-    RewriteCond %{HTTP:Accept-Language} ^da [NC]
-    RewriteRule ^$ ${BASE_URL}da/ [R,L]
-
-    RewriteCond %{HTTP:Accept-Language} ^en [NC]
-    RewriteRule ^$ ${BASE_URL}en/ [R,L]
-
-    RewriteCond %{HTTP:Accept-Language} ^es [NC]
-    RewriteRule ^$ ${BASE_URL}es/ [R,L]
-
-    RewriteCond %{HTTP:Accept-Language} ^fi [NC]
-    RewriteRule ^$ ${BASE_URL}fi/ [R,L]
-
-    RewriteCond %{HTTP:Accept-Language} ^fr [NC]
-    RewriteRule ^$ ${BASE_URL}fr/ [R,L]
-
-    RewriteCond %{HTTP:Accept-Language} ^nb [NC]
-    RewriteRule ^$ ${BASE_URL}nb/ [R,L]
-
-    RewriteCond %{HTTP:Accept-Language} ^sv [NC]
-    RewriteRule ^$ ${BASE_URL}sv/ [R,L]
+    RewriteCond %{HTTP:Accept-Language} ^(da|en|es|fi|fr|nb|sv) [NC]
+    RewriteRule ^$ ${BASE_URL}%1/ [R,L]
 
     # Default locale
     RewriteRule ^$ ${BASE_URL}en/ [R,L]

--- a/zonemaster.conf-example
+++ b/zonemaster.conf-example
@@ -22,11 +22,16 @@
     RewriteRule ^../index\.html$ - [L]
 
     # Rewrite /<LANG>/assets/ to /assets to share the assets directory
-    RewriteRule ^../(assets/.+) $1 [L]
+    RewriteRule ^(.+)/(assets/.+) $2 [L]
 
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule (..) $1/index.html [L]
+    RewriteRule "^(da|en|es|fi|fr|nb|sv)" $1/index.html [L]
+
+    # Rewrite path to new language scheme using preferred locale
+    RewriteCond $1 "!^(da|en|es|fi|fr|nb|sv|assets)"
+    RewriteCond %{HTTP:Accept-Language} ^(da|en|es|fi|fr|nb|sv) [NC]
+    RewriteRule ^(.+)$ %1/index.html [L]
 
     # Redirect user based on prefered locale
     RewriteCond %{HTTP:Accept-Language} ^(da|en|es|fi|fr|nb|sv) [NC]


### PR DESCRIPTION
## Purpose

Make URLs of the old URL scheme redirect to their counterparts in the new URL scheme.

## Context

Fixes #378.
This was first implemented in #349 and later broken in #376. 

## Changes

...

## How to test this PR

Follow the testing instructions for #331, #332, #334, #339 and #349.