### PR TITLE
Improve accessibility of the result page

### DIFF
--- a/e2e/FR22.e2e-spec.ts
+++ b/e2e/FR22.e2e-spec.ts
@@ -16,10 +16,12 @@ test.describe('Zonemaster test FR22 - [Provide the possibility to see more infor
     await page.locator('#input_domain_form').type('results.afNiC.Fr');
     await page.locator('div button.launch').click();
 
-    const basicHeader = page.locator('.result h3[aria-controls="module-BASIC"]');
-    const basicTestcases = page.locator('#module-BASIC article')
-    ;
-    const basic02Header = page.locator('.result div[aria-controls="testcase-entries-BASIC02 testcase-id-BASIC02"]');
+    // Basic header is the second one
+    const basicHeader = page.locator('.result h3').nth(1);
+    const basicTestcases = page.locator('#module-BASIC article');
+
+    // Basic02 header is the second one in the Basic results
+    const basic02Header = page.locator('#module-BASIC h4').nth(1);
     const basic02Messages = page.locator('#testcase-entries-BASIC02 li');
 
     await expect(basicHeader).toBeVisible({ timeout: 10000 });

--- a/src/app/components/result/result.component.css
+++ b/src/app/components/result/result.component.css
@@ -1,15 +1,3 @@
-article header div > i.fa {
-  margin-right: 3rem;
-  margin-top: 0.1rem;
-  width: 1rem;
-}
-
-article h4 {
-  font-size: 1rem;
-  display: inline-block;
-  margin: 0;
-}
-
 .result {
   --result-info-color: #157347;
   --result-info-bg: var(--result-info-color);
@@ -43,7 +31,19 @@ article header.critical {
   color: var(--result-critical-color);
 }
 
-article h4 i {
+article header button > i.fa {
+  margin-right: 3rem;
+  margin-top: 0.1rem;
+  width: 1rem;
+}
+
+article h4 {
+  font-size: 1rem;
+  display: inline-block;
+  margin: 0;
+}
+
+article h4 .testcase-name i {
   width: 1rem;
   display: inline-block;
   text-align: center;
@@ -51,12 +51,20 @@ article h4 i {
   margin-right: 0.3rem;
 }
 
+article h4 button {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+  text-align: left;
+}
+
 article header  {
   display: flex;
   align-items: baseline;
 }
 
-article header div {
+article header h4 {
   display: flex;
   cursor: pointer;
   margin: 0.25rem 0;
@@ -141,15 +149,22 @@ article ul {
 }
 
 article h3 {
+  margin-bottom: 0;
+  font-size: 1.4rem;
+}
+article h3 button {
   display: flex;
   align-items: center;
-  font-size: 1.4rem;
   cursor: pointer;
-  margin-bottom: 0;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
 }
 
-article h3 div.badge:first-of-type {
-  margin-left: 1rem;
+article h3 .module-name {
+  margin-right: 1rem;
 }
 
 article h3 .badge {
@@ -166,14 +181,14 @@ article.expanded h3 {
 }
 
 article h3 i.caret {
-  transform: rotate(0), translate(0, 0);
+  transform: rotate(0);
   transition: 0.1s transform;
   display: inline-block;
   width: 1em;
 }
 
 article.expanded h3 i.caret {
-  transform: rotate(90deg) translate(0.3em, 0.15em);
+  transform: rotate(90deg);
 }
 
 .result section.details > article {

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -13,13 +13,13 @@
     </div>
     <div class="actions-btn">
       <div>
-        <button class="btn btn-secondary history" (click)="getHistory()" tabindex="0">
+        <button type="button" class="btn btn-secondary history" (click)="getHistory()" tabindex="0">
           <i class="fa fa-history text-white" aria-hidden="true"></i>
           <span class="text-white" i18n>History</span>
         </button>
 
         <div ngbDropdown placement="bottom" class="d-inline-block">
-          <button class="btn btn-secondary export" id="exportDropdownResult" ngbDropdownToggle>
+          <button type="button" class="btn btn-secondary export" id="exportDropdownResult" ngbDropdownToggle>
             <i class="fa fa-cloud-download text-white" aria-hidden="true"></i>
             <span class="text-white" i18n>Export</span>
           </button>
@@ -34,7 +34,7 @@
         </div>
 
         <div ngbDropdown placement="bottom-end" class="d-inline-block">
-          <button class="btn btn-secondary share" id="shareDropdownResult" ngbDropdownToggle>
+          <button type="button" class="btn btn-secondary share" id="shareDropdownResult" ngbDropdownToggle>
             <i class="fa fa-share text-white" aria-hidden="true"></i>
             <span class="text-white" i18n>Share</span>
           </button>
@@ -148,44 +148,51 @@
   </div>
   <section class="mt-3 details">
     <article *ngFor="let module of modules" [class.expanded]="!isCollapsed[module.name]">
-      <h3
-        tabindex="0"
-        (keydown)="onCallapsableKeyDownEvent($event, module.name)"
-        (click)="isCollapsed[module.name] = !isCollapsed[module.name]"
-        [attr.aria-expanded]="!isCollapsed[module.name]"
-        [attr.aria-controls]="'module-' + module.name"
-        role="button"
-        >
-          <i class="fa fa-caret-right caret" aria-hidden="true"></i>{{module.name}}<span class="sr-only">:</span>
-          <div *ngFor="let count of testCasesCountByModule[module.name]; let last = last;" class="badge badge-pill rounded-pill {{ count.name }}" title="{{ count.name | titlecase }} ({{ count.value }})">
-            <span aria-hidden="true">
-              <i class="fa {{severity_icons[count.name]}}"></i> {{ count.value }}
+      <h3>
+          <button
+            type="button"
+            tabindex="0"
+            (click)="isCollapsed[module.name] = !isCollapsed[module.name]"
+            [attr.aria-expanded]="!isCollapsed[module.name]"
+            [attr.aria-controls]="'module-' + module.name"
+            id="control-module-{{module.name}}"
+          >
+            <i class="fa fa-caret-right caret" aria-hidden="true"></i>
+            <span class="module-name">
+              {{module.name}}
+              <span class="sr-only">:</span>
             </span>
-            <span class="sr-only">{{ count.name }} ({{ count.value }})<ng-container *ngIf="!last">, </ng-container></span>
-          </div>
+            <span *ngFor="let count of testCasesCountByModule[module.name]; let last = last;" class="badge badge-pill rounded-pill {{ count.name }}" title="{{ count.name | titlecase }} ({{ count.value }})">
+              <span aria-hidden="true">
+                <i class="fa {{severity_icons[count.name]}}"></i> {{ count.value }}
+              </span>
+              <span class="sr-only">{{ count.name }} ({{ count.value }})<ng-container *ngIf="!last">, </ng-container></span>
+            </span>
+          </button>
       </h3>
-      <div id="module-{{ module.name }}">
+      <div id="module-{{ module.name }}" role="region" [attr.aria-labelledby]="'control-module-' + module.name">
         <article *ngFor="let testcase of module.testcases" [class.collapsed]="isCollapsed[module.name]">
           <header class="{{testcase.level}}" *ngIf="testcase.id != 'UNSPECIFIED'">
-            <div
-              tabindex="0"
-              (keydown)="onCallapsableKeyDownEvent($event, testcase.id)"
-              (click)="isCollapsed[testcase.id] = !isCollapsed[testcase.id]"
-              [attr.aria-controls]="'testcase-entries-' + testcase.id + ' testcase-id-' + testcase.id"
-              [attr.aria-expanded]="!isCollapsed[testcase.id]"
-              role="button"
-            >
-              <i class="fa" aria-hidden="true" [ngClass]="{'fa-plus-square-o': isCollapsed[testcase.id],'fa-minus-square-o': !isCollapsed[testcase.id]}"></i>
+            <h4>
+              <button
+                type="button"
+                tabindex="0"
+                (click)="isCollapsed[testcase.id] = !isCollapsed[testcase.id]"
+                [attr.aria-controls]="'testcase-entries-' + testcase.id + ' testcase-id-' + testcase.id"
+                [attr.aria-expanded]="!isCollapsed[testcase.id]"
+              >
+                <i class="fa" aria-hidden="true" [ngClass]="{'fa-plus-square-o': isCollapsed[testcase.id],'fa-minus-square-o': !isCollapsed[testcase.id]}"></i>
 
-              <h4>
-                <i class="fa {{severity_icons[testcase.level]}}" aria-hidden="true" title="{{ testcase.level | titlecase }}"></i><span class="sr-only">{{ testcase.level | titlecase }}: </span>{{ testCaseDescriptions[testcase.id] }}
-              </h4>
-            </div>
+                <span class="testcase-name">
+                  <i class="fa {{severity_icons[testcase.level]}}" aria-hidden="true" title="{{ testcase.level | titlecase }}"></i><span class="sr-only">{{ testcase.level | titlecase }}: </span>{{ testCaseDescriptions[testcase.id] }}
+                </span>
+              </button>
+            </h4>
             <span class="test-case-id" [class.collapsed]="isCollapsed[testcase.id]" id="testcase-id-{{testcase.id}}">
               <i class="fa fa-info-circle" aria-hidden="true"></i> {{testcase.id}}
             </span>
           </header>
-          <div [class.collapsed]="isCollapsed[testcase.id]" id="testcase-entries-{{testcase.id}}">
+          <div [class.collapsed]="isCollapsed[testcase.id]" [attr.id]="testcase.id === 'UNSPECIFIED' ? null : 'testcase-entries-' + testcase.id">
             <ul>
               <li *ngFor="let entry of testcase.entries"><div><span class="level {{entry.level|lowercase}}">{{entry.level | titlecase}}</span></div><p> {{entry.message}} </p></li>
             </ul>

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -109,36 +109,11 @@ export class ResultComponent implements OnInit, OnDestroy {
     });
   }
 
-  public onCallapsableKeyDownEvent(event, testCaseId) {
-    switch (event.key) {
-      case 'Enter':
-        this.isCollapsed[testCaseId] = !this.isCollapsed[testCaseId];
-        break;
-    }
-  }
-
-  public onModuleKeyDownEvent(event, moduleKey) {
-    switch (event.key) {
-      case 'Enter':
-        this.isCollapsed[moduleKey] = !this.isCollapsed[moduleKey];
-        break;
-    }
-  }
-
   public onFilterLevelKeyDownEvent(event, level) {
     switch (event.key) {
       case 'Enter':
         this.togglePillFilter(level);
         break;
-    }
-  }
-
-  public moduleCollapsed(headerRef) {
-    let headerRect = headerRef.getBoundingClientRect();
-
-    if (headerRect.top < 0) {
-      let style = window.getComputedStyle(headerRef);
-      window.scrollBy(0, headerRect.top - parseInt(style.top, 10) )
     }
   }
 


### PR DESCRIPTION
## Purpose

Improve accessibility of the result page

## Context

\-

## Changes

The page looks and behave mostly the same way as before.

Notable changes:
* Wrap heading content into a button element that is itself in a heading element (`<h3><button>content</button></h3>`) for modules and testcases. Before that a heading with button role was used, as a result the element was loosing the semantic of the heading, this might have impacted people navigating by heading (eg. when using a braille or screen reader).
* Side effect of the change: improve keyboard navigation, the space key can now be used as well as the enter key to toggle module and test cases.

## How to test this PR

1. Navigate to a test result.
2. Open and close module and test case sections using the mouse.
3. Try doing the same using the keyboard (use tab to focus) using both the enter and space key.
4. Verify that no visual regression has appeared.
