### PR TITLE
Improve footer

### DIFF
--- a/src/app/components/footer/footer.component.css
+++ b/src/app/components/footer/footer.component.css
@@ -2,16 +2,36 @@ footer {
   box-shadow: inset -1px 7px 5px -9px rgba(0,0,0,0.75);
 }
 
-footer .version {
+footer dl.version {
   display: grid;
   grid-template-columns: auto auto;
   grid-gap: 0.25rem 0.5rem;
+  margin: 0;
 }
 
-footer .version div:nth-of-type(odd) {
+footer dl.version dt {
   text-align: start;
+  font-weight: normal;
 }
 
-footer .version div:nth-of-type(even) {
+footer dl.version dd {
   text-align: end;
+  margin: 0;
+}
+
+footer .copyright {
+  color: #4d5357;
+}
+
+footer i.fa {
+  margin-right: .25rem;
+}
+
+footer nav ul {
+  padding: 0;
+  margin: 0;
+}
+
+footer nav li {
+  list-style: none;
 }

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,36 +1,38 @@
 <footer class="pb-0 pt-2 bg-light">
   <div class="container">
-    <div class="row justify-content-between">
-      <div class="col-md-4">
-          <span placement="top" [ngbTooltip]="tipContent" i18n tabindex="0">Program versions</span>
-      </div>
-      <div class="col-md-5 pull-right">
-        <div class="row">
-          <div class="col-md-6">
-            <i class="fa fa-envelope-o" aria-hidden="true"></i>
-            <a class="text-dark" href="mailto:{{contactAddress}}">{{contactAddress}}</a>
-          </div>
-          <div class="col-md-4">
-            <i class="fa fa-github" aria-hidden="true"></i>
-            <a class="text-dark" href="https://github.com/zonemaster/zonemaster">Github</a>
-          </div>
-        </div>
-      </div>
-    </div>
+    <nav class="row justify-content-between">
+      <ul class="row">
+        <li class="col-md">
+            <span placement="top" [ngbTooltip]="tipContent" i18n tabindex="0">Program versions</span>
+        </li>
+        <li class="col-md-auto">
+          <i class="fa fa-envelope-o" aria-hidden="true"></i>
+          <a class="text-dark" href="mailto:{{contactAddress}}">{{contactAddress}}</a>
+        </li>
+        <li class="col-md-auto">
+          <i class="fa fa-code" aria-hidden="true"></i>
+          <a class="text-dark" href="https://github.com/zonemaster/zonemaster">Source code</a>
+        </li>
+        <li class="col-md-auto">
+          <i class="fa fa-book" aria-hidden="true"></i>
+          <a class="text-dark" href="https://github.com/zonemaster/zonemaster#documentation">Documentation</a>
+        </li>
+      </ul>
+    </nav>
 
     <div class="row">
-      <div class="col-md-12">
-        <p class="copyright text-muted small" i18n>Copyright © AFNIC and The Swedish Internet Foundation. All Rights Reserved</p>
+      <div class="col-md-auto">
+        <p class="copyright small" i18n>Copyright © AFNIC and The Swedish Internet Foundation. All Rights Reserved</p>
       </div>
     </div>
   </div>
 </footer>
 
 <ng-template #tipContent>
-  <div class="version">
+  <dl class="version">
     <ng-container *ngFor="let item of versions">
-      <div>{{ item[0] }}</div>
-      <div>{{ item[1] }}</div>
+      <dt>{{ item[0] }}</dt>
+      <dd>{{ item[1] }}</dd>
     </ng-container>
-  </div>
+  </dl>
 </ng-template>

--- a/src/app/interceptors/mock.interceptor.ts
+++ b/src/app/interceptors/mock.interceptor.ts
@@ -8,7 +8,7 @@ const urls = [
     url: 'https://zonemaster.net/api',
     body: {jsonrpc: '2.0', id: 1643203570632, method:'version_info', params: {}},
     method: 'POST',
-    json: {jsonrpc: '2.0', id: 1643203570632, result: {zonemaster_engine: 'e2e-test', zonemaster_backend: 'e2e-test'}}
+    json: {jsonrpc: '2.0', id: 1643203570632, result: {zonemaster_engine: 'e2e-test', zonemaster_backend: 'e2e-test', zonemaster_ldns: 'e2e-test'}}
   },
 
   // Profile list in option


### PR DESCRIPTION
## Purpose

Fix alignment issue and improve accessibility.

## Context

\-

## Changes

* Move footer links into a `<ul>` into a `<nav>`
* Add a link for documentation (was blocking https://github.com/zonemaster/zonemaster-gui/pull/383 and might be useful now that we have all public documentation in the same place)
* Fix alignment issue of the "Github" link and bad wrapping of the contact email on medium-small screen
* Use a  `<dl>` for program versions
* Improve color contrast for copyright text

Before
![Screenshot 2023-04-25 at 12-44-47 Zonemaster](https://user-images.githubusercontent.com/19394895/234255220-beb5f588-4ad1-46d7-baac-cb11c716b7e9.png)

After
![Screenshot 2023-04-25 at 12-45-05 toto com · Zonemaster](https://user-images.githubusercontent.com/19394895/234255155-4de93105-4636-45bd-98a4-ac69b7c4ef86.png)


## How to test this PR

* Try to resize the viewport and check that the footer content is wrapping correctly.
