### PR TITLE
Moves HTML anchor into header and creates valid HTML

### DIFF
--- a/docs/FAQ/gui-faq-da.md
+++ b/docs/FAQ/gui-faq-da.md
@@ -17,8 +17,7 @@ Zonemaster
 
 Zonemaster
 ----------
-<a name="q1"></a>
-#### 1. Hvad er Zonemaster?
+#### <span id="q1"></span>1. Hvad er Zonemaster?
 Zonemaster er et program designet til at hjælpe med at tjekke, måle
 og forhåbentlig også forstå DNS (Domain Name System).
 
@@ -35,13 +34,11 @@ Webinterface) vil Zonemaster undersøge domænenavnets generelle sundhed på bag
 en serie test. De forskellige sundhedstjek foretaget af Zonemaster er dokumenteret i
 [Test Requirements].
 
-<a name="q2"></a>
-#### 2. Hvem står bag Zonemaster?
+#### <span id="q2"></span>2. Hvem står bag Zonemaster?
 Zonemaster er et fælles projekt mellem [AFNIC] (administrator af .fr samt mange andre TLD'er,
 herunder .re, .pm, .tf, .yt og .paris) og [IIS] (administrator af .se og .nu).
 
-<a name="q3"></a>
-#### 3. Hvordan kan Zonemaster hjælpe mig?
+#### <span id="q3"></span>3. Hvordan kan Zonemaster hjælpe mig?
 Zonemaster er orienteret mod to forskellige brugere:
 
   - Brugere som ved hvordan DNS fungerer.
@@ -50,14 +47,12 @@ Zonemaster er orienteret mod to forskellige brugere:
 Den anden kategori kan med fordel kontakte deres DNS-udbyder med spørgsmål til
 testresultater, der ikke "lyser grønt" på egne domænenavne.
 
-<a name="q4"></a>
-#### 4. Zonemaster rapporterer advarsler/fejl på mit domænenavn, hvad betyder det?
+#### <span id="q4"></span>4. Zonemaster rapporterer advarsler/fejl på mit domænenavn, hvad betyder det?
 Det kommer an på hvilke advarsler/fejl, der rapporteres. I de fleste tilfælde kan
 du trykke på den aktuelle "advarsler/fejl"-besked og få detaljerede
 informationer om problemet.
 
-<a name="q5"></a>
-#### 5. Hvordan kan Zonemaster skelne mellem, hvad der er rigtigt og forkert?
+#### <span id="q5"></span>5. Hvordan kan Zonemaster skelne mellem, hvad der er rigtigt og forkert?
 Der er ikke nogen endegyldig dom over et domænenavns sundhed. Folkene bag Zonemaster påstår ikke,
 at værktøjet er korrekt i ethvert aspekt. Sommetider er meninger forskellige, især mellem lande,
 men nogle gange også lokalt. Vi har gjort vores bedste for at skabe en standard ([RFCs]).
@@ -71,17 +66,14 @@ sende os en e-mail på adressen [zonemaster-users@lists.iis.se] (moderated maili
 link til din test og en forklaring på, hvorfor du mener, at resultatet viser noget,
 som du anser forkert.
 
-<a name="q6"></a>
-#### 6. Understøtter Zonemaster IPv6?
+#### <span id="q6"></span>6. Understøtter Zonemaster IPv6?
 Ja. Som udgangspunkt vil Zonemaster forespørge navneservere over IPv4 og IPv6, medmindre andet
 er konfigureret under "Valgmuligheder".
 
-<a name="q7"></a>
-#### 7. Understøtter Zonemaster DNSSEC?
+#### <span id="q7"></span>7. Understøtter Zonemaster DNSSEC?
 Ja. Hvis DNSSEC er tilgængeligt på et domænenavn, vil det automtisk blive testet.
 
-<a name="q8"></a>
-#### 8. Hvad gør Zonemaster forkellig fra andre tilsvarende test-værktøjer?
+#### <span id="q8"></span>8. Hvad gør Zonemaster forkellig fra andre tilsvarende test-værktøjer?
 Først og fremmest gemmer Zonemaster al historik fra tidligere tests, hvilket betyder, at du kan
 gå tilbage til en tidligere test og sammenligne den med den test som du har udført for
 et øjeblik siden.
@@ -95,14 +87,12 @@ Sidst, men ikke mindst, så er Zonemaster open source og opbygget af flere modul
 betyder, at du kan bruge de dele, der er relevante i dit system. Det er sjældent, at du
 ønsker den fulde installation, såfremt du eksempelvis blot ønsker at teste redelegeringer.
 
-<a name="q9"></a>
-#### 9. Zonemaster og privatliv
+#### <span id="q9"></span>9. Zonemaster og privatliv
 Da Zonemaster er tilgængelig for alle, er det muligt for hvem som helst at tjekke dit
 domænenavn samt læse tidligere testresultater. Det er ikke muligt at se, hvem der
 har udført de enkelte tests, da det udelukkende er tidspunktet for testen, der logges.
 
-<a name="q10"></a>
-#### 10. Hvorfor kan jeg ikke teste mit domænenavn?
+#### <span id="q10"></span>10. Hvorfor kan jeg ikke teste mit domænenavn?
 Bortset fra den situation, hvor domænenavnet ikke eksisterer, findes der 2 andre muligheder:
 
   - For at beskytte motoren mod flere samtidige tests (den samme IP-adresse tester
@@ -114,8 +104,7 @@ Bortset fra den situation, hvor domænenavnet ikke eksisterer, findes der 2 andr
     værtsnavne (som www.zonemaster.dk) udfører Zonemasters webinterface et pre-tjek af dit
     domænenavn, før det sendes videre til test-motoren.
 
-<a name="q11"></a>
-#### 11. Hvilke typer af forespørgsler genererer Zonemaster?
+#### <span id="q11"></span>11. Hvilke typer af forespørgsler genererer Zonemaster?
 Dette spørgsmål er meget svært at svare på, da Zonemaster genererer forskellige
 forespørgsler afhængigt af de svar som den får fra navneserverne. Den eneste måde
 at få et fuldt overblik over forespørgsler, er at afvikle kommandolinjeværktøjet
@@ -124,8 +113,7 @@ er det muligt at få indblik i samtlige forespørgsler, der sendes fra Zonemaste
 Bemærk venligst, at informationerne fra kommandolinjeværktøjet er meget tekniske,
 og kræver en høj viden indenfor DNS.
 
-<a name="q12"></a>
-#### 12. Hvad er en "ikke-delegeret" test?
+#### <span id="q12"></span>12. Hvad er en "ikke-delegeret" test?
 En "ikke-delegeret" test af et domænenavn betyder, at testen udføres på et
 domænenavn, der måske eller måske ikke er offentliggjort i DNS. Dette kan være
 ganske nyttigt, såfremt man ønsker at udskifte navneservere bag et domænenavn
@@ -134,8 +122,7 @@ inden redelegering. Såfremt Zonemasters testresultat er "grønt", er der stor
 sandsynlighed for, at de nye navneservere er konfigureret korrekt, og en
 redelegering vil kunne udføres med succes.
 
-<a name="q13"></a>
-#### 13. Hvordan tester jeg en "reverse" zone med Zonemaster?
+#### <span id="q13"></span>13. Hvordan tester jeg en "reverse" zone med Zonemaster?
 For at kontrollere en "reverse" zone med Zonemaster, skal man først vide,
 hvad en "reverse" zone er. Hvis du vil kontrollere en "reverse" zone,
 skal du indtaste den i det format, den har i DNS, f.eks.:

--- a/docs/FAQ/gui-faq-en.md
+++ b/docs/FAQ/gui-faq-en.md
@@ -19,8 +19,7 @@ Zonemaster
 Zonemaster
 ----------
 
-<a name="q1"></a>
-#### 1. What is Zonemaster?
+#### <span id="q1"></span>1. What is Zonemaster?
 Zonemaster is a program designed to help people check, measure and
 hopefully also understand how the DNS (Domain Name System) works.
 
@@ -36,14 +35,12 @@ When a domain name (such as 'zonemaster.net') is submitted to Zonemaster (using 
 GUI), it will verify the domain name’s general health with a series of tests.
 The tests conducted by Zonemaster can be found in the [Defined Test Cases] document.
 
-<a name="q2"></a>
-#### 2. Who is behind Zonemaster?
+#### <span id="q2"></span>2. Who is behind Zonemaster?
 Zonemaster is a joint project between [AFNIC] (registry of '.fr' TLD and several other
 TLDs, e.g. '.re', '.pm', '.tf', '.wf', '.yt' and '.paris') and [The Swedish Internet Foundation]
 (registry of '.se' and '.nu' TLDs).
 
-<a name="q3"></a>
-#### 3. How can Zonemaster help me?
+#### <span id="q3"></span>3. How can Zonemaster help me?
 The Zonemaster tool is oriented towards two user categories:
 
   - Users who are knowledgable about the DNS protocol.
@@ -53,14 +50,12 @@ The Zonemaster tool is oriented towards two user categories:
 Users of the second category should contact their DNS operator
 in case there are errors or warnings for any test of their domain name.
 
-<a name="q4"></a>
-#### 4. Zonemaster returns "Error" or "Warning" for my domain name. What does it mean?
+#### <span id="q4"></span>4. Zonemaster returns "Error" or "Warning" for my domain name. What does it mean?
 It depends on which test failed for your domain name.
 Each test are accompanied with one or several messages describing the issues found.
 You can also get further insight about each test from the [Defined Test Cases] document.
 
-<a name="q5"></a>
-#### 5. How can Zonemaster distinguish between what is right and wrong?
+#### <span id="q5"></span>5. How can Zonemaster distinguish between what is right and wrong?
 The judgement of Zonemaster is primarily based on the DNS standards as defined in [RFCs].
 It also bases its judgement on DNS best practices, which can be more loosely defined.
 All Zonemaster tests are defined in [Test Case Specifications][Defined Test Cases]
@@ -75,21 +70,18 @@ If you think we have made a mistake in our judgement please do not hesitate to s
 at [zonemaster-users@lists.iis.se] (moderated mailing list) with a link to your test result
 and an explanation as to why you think it shows something that you consider incorrect.
 
-<a name="q6"></a>
-#### 6. Does Zonemaster support IPv6?
+#### <span id="q6"></span>6. Does Zonemaster support IPv6?
 Yes.
 By default Zonemaster will query name servers both over IPv4 and IPv6, unless explicitly
 configured otherwise.
 Such configuration is accessible through the "Options" button.
 
-<a name="q7"></a>
-#### 7. Does Zonemaster verify DNSSEC?
+#### <span id="q7"></span>7. Does Zonemaster verify DNSSEC?
 Yes.
 If DNSSEC is available for a domain name that is tested by Zonemaster, it will be
 checked automatically.
 
-<a name="q8"></a>
-#### 8. What makes Zonemaster differ from other DNS zone validating software?
+#### <span id="q8"></span>8. What makes Zonemaster differ from other DNS zone validating software?
 Firstly, Zonemaster saves all history from earlier tests based on the tested
 domain name, which means you can go back to a test you did some time ago and compare it
 to the test you ran just a moment ago.
@@ -109,8 +101,7 @@ which basically means that you can integrate parts of it in your own systems, if
 For example, it is quite rare that you would want a complete program just to check for
 redelegations.
 
-<a name="q9"></a>
-#### 9. Zonemaster and privacy
+#### <span id="q9"></span>9. Zonemaster and privacy
 Since [Zonemaster.net] is open to everyone it is possible for anyone to check your
 domain and its history of tests.
 However there is no way to tell who has run a specific test since nothing more than the test
@@ -118,8 +109,7 @@ parameters and results are stored.
 Specifically, no cookies or information on the user's IP address is stored in the database.
 The user who initiated the test cannot be traced back from the information in the database.
 
-<a name="q10"></a>
-#### 10. How come my domain name cannot be tested?
+#### <span id="q10"></span>10. How come my domain name cannot be tested?
 There are several possibilities:
 
 - Your domain name is not yet delegated.
@@ -129,8 +119,7 @@ There are several possibilities:
   Running a test within that window will instead show the last available test for that domain name (and parameters).
 - You have misspelled your domain name.
 
-<a name="q11"></a>
-#### 11. What kind of queries does Zonemaster generate?
+#### <span id="q11"></span>11. What kind of queries does Zonemaster generate?
 Zonemaster send multiple DNS queries to the name servers hosting the domain name being tested and
 also to the name servers hosting the parent zone of that domain name.
 
@@ -141,8 +130,7 @@ Queries sent can be shown using the 'DEBUG' level option.
 Fair warning, the output from the CLI can be quite heavy.
 For more information see [Using The CLI].
 
-<a name="q12"></a>
-#### 12. What is an undelegated domain test?
+#### <span id="q12"></span>12. What is an undelegated domain test?
 An undelegated domain test is a test performed on a domain name that may, or may not,
 be fully published in the DNS.
 This can be quite useful if one is going to migrate one's domain from one registrar to another,
@@ -153,14 +141,12 @@ When the results of the test doesn't show any errors or warnings one can be fair
 domain's new location is working well.
 However there might still be other problems in the zone data itself that this test is unaware of.
 
-<a name="q13"></a>
-#### 13. Can I test the DS records before they are published?
+#### <span id="q13"></span>13. Can I test the DS records before they are published?
 Yes.
 Use the "Options" button and there add the Delegation Signer (DS) records to be tested.
 Zonemaster will then use those in the same way as if they were already added in the parent zone.
 
-<a name="q14"></a>
-#### 14. How can I test a "reverse" zone with Zonemaster?
+#### <span id="q14"></span>14. How can I test a "reverse" zone with Zonemaster?
 To check a reverse zone with Zonemaster, one first needs to know what the
 reverse zone is, and enter it in the format it has in the DNS.
 A reserve zone is obtained by reversing an IP address and adding a suffix.

--- a/docs/FAQ/gui-faq-es.md
+++ b/docs/FAQ/gui-faq-es.md
@@ -19,8 +19,7 @@ Zonemaster
 Zonemaster
 ----------
 
-<a name="q1"></a>
-#### 1. ¿Qué es Zonemaster?
+#### <span id="q1"></span>1. ¿Qué es Zonemaster?
 Zonemaster es un programa diseñado para ayudar a la gente a revisar,
 medir y ojalá también entender cómo funciona el DNS (Sistema de Nombres de
 Dominio).
@@ -38,16 +37,14 @@ una serie de pruebas.
 Las distintas pruebas realizadas por Zonemaster están documentadas en el
 documento de [Definición de Casos de Pruebas] (en inglés).
 
-<a name="q2"></a>
-#### 2. ¿Quién está detrás de Zonemaster?
+#### <span id="q2"></span>2. ¿Quién está detrás de Zonemaster?
 Zonemaster es un proyecto conjunto entre [AFNIC]
 (registro para el TLD .fr y varios otros, por ejemplo
 .re, .pm, .tf, .wf, .yt y .paris) y
 [The Swedish Internet Foundation]
 (registro de los TLDs .se y .nu).
 
-<a name="q3"></a>
-#### 3. ¿Cómo me puede ayudar Zonemaster?
+#### <span id="q3"></span>3. ¿Cómo me puede ayudar Zonemaster?
 La herramienta Zonemaster está orientada a dos categorías de usuarios:
 
   - Usuarios que entienden bien el protocolo DNS.
@@ -57,15 +54,13 @@ Los usuarios de la segunda categoría deberían contactar a sus operadores
 DNS tan pronto obtengan resultados distintos a "verde" en cualquiera
 de las pruebas sobre sus nombres de dominio.
 
-<a name="q4"></a>
-#### 4. Zonemaster indica "Error" o "Advertencia" en mi dominio. ¿Qué significa?
+#### <span id="q4"></span>4. Zonemaster indica "Error" o "Advertencia" en mi dominio. ¿Qué significa?
 Depende cuáles de las pruebas fallaron en su dominio. Cada prueba está
 acompañada por uno o más mensajes que describen los problemas encontrados.
 También puede encontrar más detalles de cada prueba en el documento de
 [Definición de Casos de Pruebas] (en inglés).
 
-<a name="q5"></a>
-#### 5. ¿Cómo puede juzgar Zonemaster qué está bien y qué está mal?
+#### <span id="q5"></span>5. ¿Cómo puede juzgar Zonemaster qué está bien y qué está mal?
 El criterio de Zonemaster se basa principalmente en los estándares
 DNS definidos en los [RFCs]. También basa su criterio en las mejores
 prácticas del DNS, que pueden ser definiciones un poco más vagas.
@@ -86,21 +81,18 @@ al resultado de tu prueba y una explicación por qué crees que muestra
 algo que consideres incorrecto.
 
 
-<a name="q6"></a>
-#### 6. ¿Zonemaster soporta IPv6?
+#### <span id="q6"></span>6. ¿Zonemaster soporta IPv6?
 Sí.
 Por defecto Zonemaster consultará a los servidores de nombre usando
 IPv4 e IPv6, a menos que sea configurado explícitamente de otra forma.
 Esta configuración se encuentra en el botón "Opciones".
 
-<a name="q7"></a>
-#### 7. ¿Zonemaster verifica DNSSEC?
+#### <span id="q7"></span>7. ¿Zonemaster verifica DNSSEC?
 Sí.
 En caso que un nombre de dominio que esté en prueba por Zonemaster tenga
 soporte DNSSEC, será revisado automáticamente.
 
-<a name="q8"></a>
-#### 8. ¿Qué hace distinto a Zonemaster de otros software de validación DNS?
+#### <span id="q8"></span>8. ¿Qué hace distinto a Zonemaster de otros software de validación DNS?
 Primero que todo, Zonemaster guarda toda la historia de pruebas anteriores
 basadas en el nombre del dominio probado, de tal forma que puedes ir hacia atrás
 a una prueba que hiciste hace un tiempo, y compararla con la prueba
@@ -123,8 +115,7 @@ partes del software en tus propios sistemas, si así lo quisieras.
 Por ejemplo, es muy raro que quieras instalar un programa completo para
 sólo probar redelegaciones.
 
-<a name="q9"></a>
-#### 9. Zonemaster y privacidad
+#### <span id="q9"></span>9. Zonemaster y privacidad
 Dado que [Zonemaster.net] es abierto a todos, es posible que cualquiera pueda
 probar tu dominio y ver la historia de pruebas anteriores. Sin embargo, no hay
 forma de saber quién ejecutó una prueba en específico, ya que solo se
@@ -133,8 +124,7 @@ En específico, no se almacenan ni las cookies ni la dirección IP del
 usuario. El usuario que inició la prueba no puede ser rastreado usando
 la información de la base de datos.
 
-<a name="q10"></a>
-#### 10. ¿Por qué no puedo probar mi nombre de dominio?
+#### <span id="q10"></span>10. ¿Por qué no puedo probar mi nombre de dominio?
 Puede haber varias posibilidades:
 
 - Su nombre de dominio aún no está delegado.
@@ -148,8 +138,7 @@ el último resultado que se se obtuvo para ese nombre de dominio (con
 los mismos parámetros).
 - Ha escrito mal su nombre de dominio.
 
-<a name="q11"></a>
-#### 11. ¿Qué tipo de consultas genera Zonemaster?
+#### <span id="q11"></span>11. ¿Qué tipo de consultas genera Zonemaster?
 Zonemaster envía múltiples consultas DNS a los servidores de nombre que
 hospedan al nombre de dominio que se está probando, y también a los
 servidores de nombre que hospedan la zona padre del nombre de dominio.
@@ -163,8 +152,7 @@ la opción de nivel 'DEBUG'. Le advertimos que la salida del CLI
 puede ser bastante compleja. Para más información ver [Usando la CLI]
 (en inglés).
 
-<a name="q12"></a>
-#### 12. ¿Qué es una prueba de dominio no-delegado?]
+#### <span id="q12"></span>12. ¿Qué es una prueba de dominio no-delegado?]
 Una prueba de dominio no-delegado es una prueba ejecutada sobre un nombre
 de dominio que puede o no estar completamente publicado en el DNS.
 Esto es muy útil
@@ -179,16 +167,14 @@ seguro que la nueva ubicación del dominio está funcionando correctamente.
 Sin embargo, puede haber otros problemas en los datos de la zona en
 sí misma, que esta prueba ignora.
 
-<a name="q13"></a>
-#### 13. ¿Puedo probar los registros DS antes de ser publicados?</a>
+#### <span id="q13"></span>13. ¿Puedo probar los registros DS antes de ser publicados?</a>
 Sí.
 Puede utilizar el botón "Opciones" y agregar ahí los registros
 "Delegation Signer" (DS) que quiera probar. Zonemaster los usará
 de la misma forma que si hubieran sido obtenidos desde la zona
 padre.
 
-<a name="q14">i</a>
-#### 14. ¿Cómo puedo probar una zona reversa con Zonemaster?
+#### <span id="q14"></span>14. ¿Cómo puedo probar una zona reversa con Zonemaster?
 Para revisar una zona "reversa" (también llamada "inversa") con Zonemaster,
 lo primero que necesitas es saber qué zona reversa es, e ingresarla en
 el formato que tiene en el DNS.

--- a/docs/FAQ/gui-faq-fi.md
+++ b/docs/FAQ/gui-faq-fi.md
@@ -18,8 +18,7 @@ Zonemaster
 Zonemaster
 ----------
 
-#### 1. Mikä Zonemaster on? <a name="q1"></a>
-
+#### <span id="q1"></span>1. Mikä Zonemaster on? 
 Zonemaster on ohjelma, jonka tarkoitus on auttaa ihmisiä hallitsemaan ja mittaamaan DNS:ää (domain name system) ja toivottavasti myös ymmärtämään paremmin, miten se toimii. Zonemasteriin kuuluu kolme osaa:
 
 1. "Engine" – testimoottori, jolla suoritetaan kaikki DNS-testit.
@@ -29,12 +28,10 @@ Zonemaster on ohjelma, jonka tarkoitus on auttaa ihmisiä hallitsemaan ja mittaa
 
 Kun verkkotunnus lähetetään Zonemasteriin, ohjelma tutkii verkkotunnuksen kunnon käymällä DNS:n läpi juuresta (.) ylätason verkkotunnukseen (esimerkiksi .NET) ja lopuksi DNS-palvelimiin, joissa on toisen asteen verkkotunnuksia (esimerkiksi zonemaster.net) koskeva informaatio. Zonemaster suorittaa myös muita testejä. Ne on kaikki dokumentoitu täällä: [Test Requirements document](https://github.com/zonemaster/zonemaster/blob/master/docs/requirements/TestRequirements.md)
 
-#### 2. Kuka on Zonemasterin takana? <a name="q2"></a>
-
+#### <span id="q2"></span>2. Kuka on Zonemasterin takana? 
 Zonemaster on yhteistyöprojekti, jonka takana ovat [Internetstiftelsen](https://internetstiftelsen.se/) (ylätason verkkotunnusten .se ja .nu hallinnoija) ja [AFNIC](https://www.afnic.fr/en/) (ylätason verkkotunnuksen .fr sekä muiden ylätason verkkotunnusten kuten .re, .pm, .tf, .wf, .yt ja .paris hallinnoija).
 
-#### 3. Mitä hyötyä Zonemasterista on? <a name="q3"></a>
-
+#### <span id="q3"></span>3. Mitä hyötyä Zonemasterista on? 
 Zonemaster on kehitetty kahdenlaisia käyttäjiä varten:
 
   - DNS-taitoiset käyttäjät.
@@ -42,28 +39,23 @@ Zonemaster on kehitetty kahdenlaisia käyttäjiä varten:
 
 Jälkimmäiseen ryhmään kuuluvien käyttäjien tulee kääntyä DNS-operaattorin puoleen, jos testissä jokin tulos ei näytä vihreää valoa.
 
-#### 4. Zonemaster näyttää virheilmoitusta tai varoitusta, kun testaan verkkotunnustani. Mitä se tarkoittaa? <a name="q4"></a>
-
+#### <span id="q4"></span>4. Zonemaster näyttää virheilmoitusta tai varoitusta, kun testaan verkkotunnustani. Mitä se tarkoittaa? 
 Riippuu siitä, mikä testi on kyseessä.
 
-#### 5. Miten Zonemaster selvittää, mikä on oikein ja mikä väärin määritetty? <a name="q5"></a>
-
+#### <span id="q5"></span>5. Miten Zonemaster selvittää, mikä on oikein ja mikä väärin määritetty? 
 Kukaan ei voi antaa lopullista, kaikenkattavaa lausuntoa verkkotunnuksen kunnosta. Tämä on tärkeää pitää mielessä. Me Zonemasterin kehittäjät emme väitä, että Zonemaster on aina oikeassa. Joistakin asioista on olemassa erilaisia mielipiteitä varsinkin eri maissa mutta joskus myös paikallisella tasolla. Yhteistyöprojektissamme olemme pyrkineet yhdessä parhaamme mukaan kehittämään profiilin, jonka avulla erilaisia virheitä voidaan arvioida mahdollisimman tehokkaasti, ennen kuin työkalu esittää ne käyttäjälle.
 
 Käyttäjänä voit helposti luoda oman profiilin, jonka avulla voit arvioida tiettyjen virheiden vakavuutta. Oman profiilin voi osoittaa suoraan CLI-työkalulla.
 
 Koska DNS kuitenkin kehittyy koko ajan, tilanteet, jotka ovat normaaleja nyt, saattavat olla tulevaisuudessa vakavia virheitä. Jos uskot löytäneesi jotakin, jonka olemme arvioineet väärin, ota epäröimättä yhteyttä osoitteeseen [zonemaster-users@lists.iis.se](mailto:zonemaster-users@lists.iis.se) (moderated mailing list) ja lähetä linkki testiisi ja selitys siitä, miksi tulos ei ole mielestäsi oikein.
 
-#### 6. Pystyykö Zonemaster käsittelemään IPv6:ta? <a name="q6"></a>
-
+#### <span id="q6"></span>6. Pystyykö Zonemaster käsittelemään IPv6:ta? 
 Pystyy. Kaikki IPv4:llä tehtävät testit voidaan tehdä myös IPv6:lla, jos Zonemaster on määritetty sitä varten.
 
-#### 7. Pystyykö Zonemaster käsittelemään DNSSEC:iä? <a name="q7"></a>
-
+#### <span id="q7"></span>7. Pystyykö Zonemaster käsittelemään DNSSEC:iä? 
 Pystyy. Jos Zonemasterilla testattavalla verkkotunnuksella on käytössä DNSSEC, se testataan automaattisesti.
 
-#### 8. Miten Zonemaster eroaa muista verkkotunnuksia testaavista ohjelmista? <a name="q8"></a>
-
+#### <span id="q8"></span>8. Miten Zonemaster eroaa muista verkkotunnuksia testaavista ohjelmista? 
 Ensinnäkin Zonemaster tallentaa kaikki testitapahtumat. Niinpä voit palata katsomaan viikko sitten tekemäsi edellisen testin tuloksia ja verrata niitä uusimpiin.
 
 Kaikki Zonemasterin tekemät testit määritellään testitapausspesifikaatioissa, joihin on linkki asiakirjassa "[Test Requirements document](https://github.com/zonemaster/zonemaster/blob/master/docs/requirements/TestRequirements.md)".
@@ -72,29 +64,24 @@ Zonemasterilla voi testata myös julkaisemattomia/delegoimattomia verkkotunnuksi
 
 Lisäksi Zonemaster on avoimen lähdekoodin ohjelma, ja sen rakenne on modulaarinen. Voit siis halutessasi ottaa koko koodin tai osia siitä käyttöösi omissa järjestelmissäsi.
 
-#### 9. Zonemaster ja yksityisyys <a name="q9"></a>
-
+#### <span id="q9"></span>9. Zonemaster ja yksityisyys 
 Koska Zonemaster on kaikkien käytössä, kuka tahansa voi myös tarkastaa verkkotunnuksesi ja myös nähdä verkkotunnuksesi testihistorian. Testien tekijää ei kuitenkaan ole mahdollista selvittää, sillä ainoa kirjattava tieto on testin ajankohta.
 
-#### 10. Miksen voi testata verkkotunnustani? <a name="q10"></a>
-
+#### <span id="q10"></span>10. Miksen voi testata verkkotunnustani? 
 Jos lähtöoletuksena on, että testattava verkkotunnus on olemassa, on kaksi mahdollista syytä siihen, ettei verkkotunnusta voi testata.
 
 1. Samaa verkkotunnusta ei voi testata useita kertoja yhtä aikaa samasta IP-osoitteesta, joten identtisten testien välillä on oltava vähintään viiden minuutin tauko. Niinpä et voi testata verkkotunnusta useammin kuin viiden minuutin välein. Jos testaat verkkotunnuksen uudelleen ennen kuin viisi minuuttia on kulunut, näytetään viimeisin tallennettu tulos.
 2. Koska Zonemaster on tarkoitettu testaamaan verkkotunnuksia merkityksessä DNS:n verkkoalue (esim. zonemaster.net) eikä verkkoalueiden isäntänimiä (esim. [www.zonemaster.net](http://www.zonemaster.net/)), se antaa virheilmoituksen, jos yrität testata tunnusta, joka ei vastaa DNS:n verkkoaluetta.
 
-#### 11. Millaisia DNS-kysymyksiä Zonemaster generoi? <a name="q11"></a>
-
+#### <span id="q11"></span>11. Millaisia DNS-kysymyksiä Zonemaster generoi? 
 Tämä on hankala kysymys, sillä Zonemaster generoi erityyppisiä kutsuja DNS-palvelintesi vastausten perusteella.
 
 Helpoiten pääset näkemään, mitä Zonemaster tarkkaan ottaen testaa, jos käytät "zonemaster-cli"-ohjelmaa eli CLI-ohjelmaa (joka sinun on ensin ladattava ja asennettava) ja valitset tulosten täyden tulostuksen. Ohjelman tulokset antavat tarkat tiedot siitä mitä testin aikana tapahtuu, mutta ne ovat teknisesti haastavia.
 
-#### 12. Mikä on delegoimaton verkkotunnustesti? <a name="q12"></a>
-
+#### <span id="q12"></span>12. Mikä on delegoimaton verkkotunnustesti? 
 Delegoimaton verkkotunnustesti tehdään verkkotunnukselle, jota ei tarvitse välttämättä olla julkaistu DNS:ssä. Se voi olla varsin hyödyllistä, jos aiot siirtää verkkotunnuksesi verkkotunnusvälittäjältä toiselle. Jos esimerkiksi verkkotunnus esimerkki.se aiotaan siirtää nimipalvelimelta &#39;ns.nic.se&#39; nimipalvelimelle &#39;ns.iis.se&#39;, voit tehdä verkkotunnukselle (esimerkki.se) delegoimattoman verkkotunnustestin sillä nimipalvelimella, johon aiot siirtää sen (ns.iis.se), ennen kuin toteutat siirron. Jos testi näyttää vihreää valoa, voit olla melko varma siitä, että verkkotunnuksesi uudessa kodissa on kaikki kunnossa. Verkkotunnuksen tiedoissa voi kuitenkin olla virheitä, joita testi ei löydä.
 
-#### 13. Miten testaan käänteisnimipalvelun verkkotunnusta? <a name="q13"></a>
-
+#### <span id="q13"></span>13. Miten testaan käänteisnimipalvelun verkkotunnusta? 
 Jotta voisit testata käänteisverkkotunnuksen, sinun on tiedettävä, mikä verkkotunnus se on. Jos haluat testata käänteisverkkotunnuksen, syötä se DNS:ssä käytettävässä muodossa, esim.:
 
   - 3.2.1.in-addr.arpa

--- a/docs/FAQ/gui-faq-fr.md
+++ b/docs/FAQ/gui-faq-fr.md
@@ -18,8 +18,7 @@ Zonemaster
 
 Zonemaster
 ----------
-<a name="q1"></a>
-#### 1. Qu'est-ce que Zonemaster ?
+#### <span id="q1"></span>1. Qu'est-ce que Zonemaster ?
 
 Zonemaster est un programme conçu pour aider à vérifier, mesurer et peut-être
 aussi aider à la compréhension du fonctionnement du DNS (_Domain Name
@@ -41,16 +40,14 @@ tests. L'ensemble des tests réalisés par Zonemaster est décrit dans le
 document intitulé [Defined Test Cases] (« cas de tests définis », document
 rédigé en anglais).
 
-<a name="q2"></a>
-#### 2. Qui se cache derrière Zonemaster ?
+#### <span id="q2"></span>2. Qui se cache derrière Zonemaster ?
 
 Zonemaster est un projet conjoint entre l'[Afnic], registre du TLD « .fr »
 ainsi que d'autres TLD, comme « .re », « .pm », « .tf », « .wf », « .yt » et
 « .paris » et [The Swedish Internet Foundation], registre suédois des TLD
 « .se » et « .nu ».
 
-<a name="q3"></a>
-#### 3. Qu'est-ce que Zonemaster peut faire pour moi ?
+#### <span id="q3"></span>3. Qu'est-ce que Zonemaster peut faire pour moi ?
 
 Zonemaster a été conçu pour deux types de publics :
 
@@ -62,16 +59,14 @@ Les utilisateurs de la seconde catégorie devraient contacter leur opérateur
 DNS si le moindre test de leur nom de domaine rapporte une erreur ou un
 avertissement.
 
-<a name="q4"></a>
-#### 4. Zonemaster indique des « Erreurs » ou « Avertissements » sur mon nom de domaine. Qu'est-ce que cela signifie ?
+#### <span id="q4"></span>4. Zonemaster indique des « Erreurs » ou « Avertissements » sur mon nom de domaine. Qu'est-ce que cela signifie ?
 
 Cela dépend du test ayant échoué pour votre nom de domaine. Chaque test est
 accompagné d'un ou plusieurs messages décrivant les problèmes qui ont été
 trouvés. Vous pouvez également trouver des détails supplémentaires sur chaque
 test dans le document intitulé [Defined Test Cases].
 
-<a name="q5"></a>
-#### 5. Comment Zonemaster discerne-t-il le bon du mauvais ?
+#### <span id="q5"></span>5. Comment Zonemaster discerne-t-il le bon du mauvais ?
 
 Le jugement de Zonemaster repose principalement sur les normes techniques du
 DNS telles qu'elles sont définies dans les [RFC]. Le jugement est également
@@ -92,8 +87,7 @@ e-mail à [zonemaster-users@lists.iis.se] (liste de diffusion modérée) avec un
 lien vers le résultat de votre test et en expliquant pourquoi vous pensez que
 Zonemaster affiche quelque chose que vous considérez comme incorrect.
 
-<a name="q6"></a>
-#### 6. Zonemaster prend-il en charge IPv6 ?
+#### <span id="q6"></span>6. Zonemaster prend-il en charge IPv6 ?
 
 Oui.
 Par défaut, Zonemaster interroge les serveurs de noms aussi bien en IPv4 qu'en
@@ -101,15 +95,13 @@ IPv6, sauf si un paramètre de configuration prescrit le contraire.
 De tels paramètres de configuration sont accessibles à travers le bouton « Options ».
 
 
-<a name="q7"></a>
-#### 7. Zonemaster vérifie-t-il DNSSEC ?
+#### <span id="q7"></span>7. Zonemaster vérifie-t-il DNSSEC ?
 
 Oui.
 Si DNSSEC est disponible pour un domaine testé par Zonemaster, des tests
 DNSSEC seront effectués automatiquement.
 
-<a name="q8"></a>
-#### 8. Qu'est-ce qui distingue Zonemaster des autres outils existants ?
+#### <span id="q8"></span>8. Qu'est-ce qui distingue Zonemaster des autres outils existants ?
 
 Premièrement, Zonemaster conserve tout l'historique des tests réalisés sur un
 nom de domaine, ce qui signifie que vous pouvez revenir en arrière pour
@@ -133,8 +125,7 @@ de Zonemaster dans vos propres systèmes, si vous le souhaitez. Par exemple, on
 souhaite rarement utiliser un logiciel complet juste pour vérifier des
 redélégations.
 
-<a name="q9"></a>
-#### 9. Zonemaster et le respect de la vie privée
+#### <span id="q9"></span>9. Zonemaster et le respect de la vie privée
 
 Puisque Zonemaster est accessible à tous, n'importe qui peut vérifier votre
 nom de domaine et consulter son historique de tests.
@@ -145,8 +136,7 @@ l'utilisateur ne sont conservés dans la base de données. L'initiateur d'un
 test ne peut pas être retrouvé à partir des informations dans la base de
 données.
 
- <a name="q10"></a>
-#### 10. Pourquoi mon nom de domaine n'a-t-il pas pu être testé ?
+ #### <span id="q10"></span>10. Pourquoi mon nom de domaine n'a-t-il pas pu être testé ?
 
 Il y a plusieurs possibilités :
 
@@ -162,8 +152,7 @@ Il y a plusieurs possibilités :
   test ;
 - Vous avez fait une faute de frappe dans le nom de domaine.
 
-<a name="q11"></a>
-#### 11. Quel genre de requêtes Zonemaster génère-t-il ?
+#### <span id="q11"></span>11. Quel genre de requêtes Zonemaster génère-t-il ?
 
 Zonemaster envoie plusieurs requêtes DNS aux serveurs de noms hébergeant le
 nom de domaine à tester ainsi qu'aux serveurs de noms hébergant la zone
@@ -179,8 +168,7 @@ affichées par l'interface en ligne de commande peut être très volumineuse.
 Pour plus d'informations, voir [Utilisation de l'interface en ligne de
 commandes] (document rédigé en anglais).
 
-<a name="q12"></a>
-#### 12. Qu'est-ce qu'un test sur un nom de domaine non délégué ?
+#### <span id="q12"></span>12. Qu'est-ce qu'un test sur un nom de domaine non délégué ?
 
 Un test sur un nom de domaine non délégué est un test effectué sur un nom de
 domaine qui peut ne pas être entièrement publié dans le DNS. Ce type de test
@@ -195,15 +183,13 @@ peut être relativement certain que le nouvel emplacement du domaine fonctionne
 bien. Mais cela n'exclut pas l'existence d'autres problèmes dans les données
 elles-mêmes de la zone que ce test n'aurait pas décelés.
 
-<a name="q13"></a>
-#### 13. Peut-on tester des enregistrements DS avant leur publication ?
+#### <span id="q13"></span>13. Peut-on tester des enregistrements DS avant leur publication ?
 
 Oui.
 Pour cela, utilisez le bouton « Options » et ajoutez-y les entrées *Delegation Signer* (DS) à tester.
 Zonemaster utilisera ces entrées-là comme si elles avaient déjà été ajoutées dans la zone parent.
 
-<a name="q14"></a>
-#### 14. Comment tester une zone inverse avec Zonemaster ?
+#### <span id="q14"></span>14. Comment tester une zone inverse avec Zonemaster ?
 
 Pour tester une zone inverse, il faut d'abord déterminer le nom de la zone
 inverse, puis la saisir dans le format qu'elle a dans le DNS. Une zone inverse

--- a/docs/FAQ/gui-faq-nb.md
+++ b/docs/FAQ/gui-faq-nb.md
@@ -19,8 +19,7 @@ Zonemaster
 Zonemaster
 ----------
 
-<a name="q1"></a>
-#### 1. Hva er Zonemaster?
+#### <span id="q1"></span>1. Hva er Zonemaster?
 Zonemaster er et verktøy for å overvåke, måle og forstå hvordan domenenavnsystemet (DNS) virker. Zonemaster består av flere deler:
 
   1. Motoren (kode som utfører testene).
@@ -34,26 +33,22 @@ Zonemaster utfører også flere andre tester. Disse er dokumentert her, [Definie
 
 Zonemaster kan teste både publiserte og upubliserte (ikke delegerte) domener.
 
-<a name="q2"></a>
-#### 2. Hvem har utviklet Zonemaster?
+#### <span id="q2"></span>2. Hvem har utviklet Zonemaster?
 Verktøyet er utviklet i et samarbeid mellom registreringstjenestene
 [AFNIC] (.fr TLD og flere andre TLDs, f.eks. .re, .pm, .tf, .wf, .yt og .paris) og
 [Internetstiftelsen] (.se og .nu TLDs).
 
-<a name="q3"></a>
-#### 3. Hvem er verktøyet laget for?
+#### <span id="q3"></span>3. Hvem er verktøyet laget for?
 Zonemaster er beregnet på profesjonelle brukere som vet hvordan DNS-protokollen fungerer. En vanlig domeneabonnent anbefales å kontakte sin domeneforhandler eller internettleverandør for å få tatt en helsesjekk på sine domener.
 
 Zonemaster er basert på åpen kildekode og er modulær. Som bruker kan du gjenbruke deler av koden i dine egne systemer hvis du ønsker det.
 
-<a name="q4"></a>
-#### 4. Zonemaster returnerer "Error" eller "Warning" på mitt domene. Hva betyr det?
+#### <span id="q4"></span>4. Zonemaster returnerer "Error" eller "Warning" på mitt domene. Hva betyr det?
 Det beror på hvilket test som gikk galt for domenet.
 Hvert testsvar innholder informasjon om hva som gikk galt med testen.
 Mer informasjon om hva som testes finnes i dokumentet [Definierte tester].
 
-<a name="q5"></a>
-#### 5. Hvordan avgjør Zonemaster hva som er rett eller feil?
+#### <span id="q5"></span>5. Hvordan avgjør Zonemaster hva som er rett eller feil?
 Det er viktig å understreke at ingen kan gi en endelig uttalelse om helsen til et domene. Zonemaster er ikke alltid fullstendig korrekt, og resultatene kan gi rom for tolkning. De som står bak testen understreker at de har gjort sitt aller beste for å utvikle en best mulig policy for vurdering av ulike feil før de blir presentert for deg som bruker verktøyet. Denne policy er basert på DNS-standarder som er definiert i ulike [RFCs].
 Alle tester er definiert i [Definierte tester]. Der er også alle referanser til forskjelling RFCer dokumentert.
 
@@ -61,16 +56,13 @@ Beskrivelse av de ulike nivåene på feilmeldinger, *notice*, *warning*, og *err
 
 Hvis du syns at et testresultat er feil så oppfordrer vi til å sende en e-post til [zonemaster-users@lists.iis.se] (moderert e-postliste) med en lenke til testresultatet og forklar hvorfor du synes testen er feil.
 
-<a name="q6"></a>
-#### 6. Håndterer Zonemaster IPv6?
+#### <span id="q6"></span>6. Håndterer Zonemaster IPv6?
 Ja, alle tester kjøres på både IPv4 og IPv6. Man kan endre på dette ved å slå på "Avansert sjekk".
 
-<a name="q7"></a>
-#### 7. Håndterer Zonemaster DNSSEC?
+#### <span id="q7"></span>7. Håndterer Zonemaster DNSSEC?
 Ja, hvis DNSSEC er konfigurert for et domene blir det automatiskt testet av Zonemaster.
 
-<a name="q8"></a>
-#### 8. Hva er det for forskjell på Zonemaster og andre DNS-testverktøy?
+#### <span id="q8"></span>8. Hva er det for forskjell på Zonemaster og andre DNS-testverktøy?
 For det første lagrer Zonemaster all historikk fra tidligere tester basert på det testede domenet. Det betyr at du kan gå tilbake til en test du gjorde for en uke siden og sammenligne den med testen du kjørte for et øyeblikk siden.
 
 Alle tester som Zonemaster kjører er definert i test-spesifikasjoner som
@@ -83,14 +75,12 @@ Zonemaster kan brukes til å teste DS-poster innen de er publisert i foreldreson
 
 Til slutt ble denne open source-versjonen av Zonemaster bygget ved hjelp av modulkode som i utgangspunktet betyr at du kan bruke deler av den i systemene dine hvis du ønsker det. Det er ganske sjelden at du har et komplett program bare for å sjekke for eksempel omlegeringer.
 
-<a name="q9"></a>
-#### 9. Zonemaster og personvern
+#### <span id="q9"></span>9. Zonemaster og personvern
 Zonemaster lagrer all historikk. Det betyr at du kan gå tilbake og se på en test du gjorde for en uke siden og sammenligne med en test du nettopp har gjort.
 
 Zonemaster er tilgjengelig for alle, dermed er det også mulig for alle å teste ditt domene og også se testhistorikk for domenet. Det er imidlertid ingen som kan se hvem som har gjort en test. Det eneste som er logget, er tidspunktet da testen ble utført. Hverken IP-adresse eller informasjonskapsler (cookies) blir lagret.
 
-<a name="q10"></a>
-#### 10. Hvorfor kan jeg ikke teste mitt domene?
+#### <span id="q10"></span>10. Hvorfor kan jeg ikke teste mitt domene?
 Det er flere muligheter:
   - Ditt domene er ikke delegert.
   - Ditt domene er ikke tilgjengelig fra internett.
@@ -100,23 +90,19 @@ Det er flere muligheter:
     His du prøver å teste det igjen innen 10 minutter vil det forrige resultatet vises i stedet.
   - Du har feilstavet ditt domene.
 
-<a name="q11"></a>
-#### 11. Hvilke typer spørringer genererer Zonemaster?
+#### <span id="q11"></span>11. Hvilke typer spørringer genererer Zonemaster?
 Zonemaster vil generere forskjellige typer spørringer avhengig av hvordan DNS-serverne svarer.
 
 For å få en full visning av hvilke spørsmål og resultater som genereres, kan du kjøre CLI-grensesnittet og velg full utdata. For å kunne kjøre CLI-grensesnittet må du laste ned pakke og installer både CLI- og Engine-komponenten. Det finnes også en Docker image.
 Resultatet fra CLI-verktøyet er ganske tungt teknisk så med mindre du er interessert i bit og byte, vil du kanskje hoppe over dette trinnet. For mer informasjon se [Bruk av CLI].
 
-<a name="q12"></a>
-#### 12. Hva er et udelegert test?
+#### <span id="q12"></span>12. Hva er et udelegert test?
 Du kan sjekke domener og navnetjenere som ikke er publisert i DNS, eller endringer av navnetjenere for et domene før endringen er publisert. Hvis testen er feilfri, kan du regne med at navnetjeneren vil svare på spørringer om domenet. Det kan imidlertid fortsatt være feil i soneinformasjonen som denne testen ikke kjenner til.
 
-<a name="q13"></a>
-#### 13. Kan jeg teste DS-poster innen de er publisert?
+#### <span id="q13"></span>13. Kan jeg teste DS-poster innen de er publisert?
 Ja, bruk valget "Avansert sjekk" for å kunne legge inn DS-poster du vil sjekke. Zonemaster bruker da de i steden for å hendte dem fra foreldresonen.
 
-<a name="q14"></a>
-#### 14. Hvordan kan jeg teste revers-soner med Zonemaster?
+#### <span id="q14"></span>14. Hvordan kan jeg teste revers-soner med Zonemaster?
 Et reversoppslag kan brukes til å finne ut hvilket domenenavn som er knyttet til en IP-adresse.
 
 For en IPv4-adresse må du først finne nettverksadressen til systemet. Denne ender oftest med en 0 (null). Du sletter siste 0 (null), deretter endrer du rekkefølgen på sifrene du har mottatt og legger til suffikset in-addr.arpa. Du gjør det samme med en IPv6-adresse, men legger til suffikset ip6.arpa.

--- a/docs/FAQ/gui-faq-sv.md
+++ b/docs/FAQ/gui-faq-sv.md
@@ -20,8 +20,7 @@ Zonemaster
 Zonemaster
 ----------
 
-<a name="q1"></a>
-#### 1. Vad är Zonemaster?
+#### <span id="q1"></span>1. Vad är Zonemaster?
 Zonemaster är ett program som är framtaget för att hjälpa användare att
 kontrollera, mäta och förhoppningsvis också bättre förstå hur DNS, "Domain Name
 System", fungerar.
@@ -39,15 +38,14 @@ När Zonemaster startar en test av ett domännamn, som "zonemaster.net" (genom
 med hjälp av en serie av test. Testen som utförs av Zonemaster finns listade i
 dokumentet "[Defined Test Cases]" (*Definierade testfall*).
 
-<a name="q2"></a>
-#### 2. Vem står bakom Zonemaster?
+
+#### <span id="q2"></span>2. Vem står bakom Zonemaster?
 Zonemaster är ett samarbetsprojekt mellan [Internetstiftelsen](https://internetstiftelsen.se/)
 (registry för .se och .nu) och [AFNIC](https://www.afnic.fr/en/)
 (registry för .fr och andra TLD:er som .re, .pm, .tf, .wf, .yt och .paris).
 
-<a name="q3"></a>
-#### 3. Hur kan Zonemaster hjälpa till?
 
+#### <span id="q3"></span>3. Hur kan Zonemaster hjälpa till?
 Zonemaster är framtaget för två kategorier av användare:
 
   - Användare med kunskap om DNS-standarden.
@@ -58,16 +56,14 @@ Användare av den andra kategorin bör vända sig till sin DNS-operatör
 ifall det finns fel eller varningar när deras domännamn testats.
 
 
-<a name="q4"></a>
-#### 4. Zonemaster visar "Fel" eller "Varning" när jag testar min domän, vad betyder det?
-
+#### <span id="q4"></span>4. Zonemaster visar "Fel" eller "Varning" när jag testar min domän, vad betyder det?
 Det beror på vilken test det gäller. Varje testfall kommer med ett eller flera
 meddelanden som beskriver det problem som har funnits. Mera detaljer om varje
 testfall kan hittas via dokumentet "[Defined Test Cases]"
 (*Definierade testfall*).
 
-<a name="q5"></a>
-#### 5. Hur kan Zonemaster bedömma vad som är rätt och fel?
+
+#### <span id="q5"></span>5. Hur kan Zonemaster bedömma vad som är rätt och fel?
 Zonemasters bedömning är i första hand baserat på DNS-standarden som den är
 definierad i [RFC:er][RFCs] (text på engelska; det finns även en
 [beskrivning av RFC i engelskspråkiga Wikipedia][Wikipedia#Engelska#RFC]).
@@ -87,20 +83,18 @@ felbedömt, tveka inte att kontakta oss på
 e-postlista) med en länk till ditt test och en förklaring av varför du anser att
 resultatet inte är korrekt.
 
-<a name="q6"></a>
-#### 6. Kan Zonemaster hantera IPv6?
 
+#### <span id="q6"></span>6. Kan Zonemaster hantera IPv6?
 Ja. Zonemaster kommer att skicka DNS frågor till namnservrarna över både IPv4
 och IPv6 om inte Zonemaster har konfigurerats på annat sätt. Under knappen
 "alternativ" så går det att ställa in detta.
 
-<a name="q7"></a>
-#### 7. Kan Zonemaster kontrollera DNSSEC?
 
+#### <span id="q7"></span>7. Kan Zonemaster kontrollera DNSSEC?
 Ja. Om en domän som testas av Zonemaster har DNSSEC konfigurerat så kommer det testas automatiskt.
 
-<a name="q8"></a>
-#### 8. Vad skiljer Zonemaster från andra program som testar domäner?
+
+#### <span id="q8"></span>8. Vad skiljer Zonemaster från andra program som testar domäner?
 För det första så sparar Zonemaster all testhistorik utifrån den testade
 domänen, vilket innebär att man kan gå tillbaka till ett tidigare test och
 jämföra med ett test som just har körts.
@@ -119,8 +113,8 @@ Och till sist, Zonemaster är öppen källkod och är modulärt uppbyggt, vilket
 betyder att man kan integrera delar av Zonemaster i sitt eget system om man
 vill.
 
-<a name="q9"></a>
-#### 9. Zonemaster och integritet
+
+#### <span id="q9"></span>9. Zonemaster och integritet
 Eftersom [Zonemaster.net] är tillgänglig för vem som helst, så kan vem som helst
 kontrollera din domän och se dess testhistorik. Å andra sidan så finns det inget
 sett att ta reda på vem som har kört ett test eftersom det bara är testparametrar
@@ -128,8 +122,8 @@ och testresultat som sparas. Specifikt så sparas inga cookies eller annan
 information om användarens IP-adress i databasen. Användaren som initierade
 testet kan inte spåras från informationen i databasen.
 
-<a name="q10"></a>
-#### 10. Varför kan jag inte testa min domän?
+
+#### <span id="q10"></span>10. Varför kan jag inte testa min domän?
 Det kan finnas flera olika anledningar till detta:
 
 - Domännamnet är ännu inte delegerat.
@@ -142,8 +136,8 @@ Det kan finnas flera olika anledningar till detta:
   test för samma domännamn (och testparametrar).
 - Domännamnet har stavats fel.
 
-<a name="q11"></a>
-#### 11. Vilken typ av DNS-frågor ställer Zonemaster?
+
+#### <span id="q11"></span>11. Vilken typ av DNS-frågor ställer Zonemaster?
 Zonemaster skickar flera DNS-frågor till namnservrarna som är hostingservrar för
 domänen som testas, men även till namnservrarna som är hostingservrar för den
 överliggande zonen till domänen som testas.
@@ -156,8 +150,8 @@ kan visas genom att välja DEBUG-nivån "--level DEBUG". Det ska poängteras att
 blir mycket som visas från CLI-gränssnittet i det fallet. För mera information se
 "[Using The CLI]" (*användardokumentet för CLI*).
 
-<a name="q12"></a>
-#### 12. Vad är ett odelegerat domäntest?
+
+#### <span id="q12"></span>12. Vad är ett odelegerat domäntest?
 Ett odelegerat domäntest är ett test som genomförs på en domän som inte
 nödvändigtvis är publicerad i DNS. Detta kan vara mycket användbart om man tänker
 flytta sin domän från en registrar till en annan, t.ex. flytta "example.se" från
@@ -169,14 +163,14 @@ flytten. När resultatet på testet inte visare några fel ("error") eller varni
 Det kan emellertid fortfarande finnas fel i zoninformationen som dessa test inte
 känner till.
 
-<a name="q13"></a>
-#### 13. Går det att testa DS-poster innan de publiceras?
+
+#### <span id="q13"></span>13. Går det att testa DS-poster innan de publiceras?
 Ja. Använd knappen "alternativ" och lägg sedan till DS-posterna ("Delegation
 Signer") som ska testas. Zonemaster kommer att använda dessa på samma sätt som
 om de redan fanns i moderzonen.
 
-<a name="q14"></a>
-#### 14. Hur kan jag testa en "baklängeszon" med Zonemaster?
+
+#### <span id="q14"></span>14. Hur kan jag testa en "baklängeszon" med Zonemaster?
 För att kunna kontrolla en "baklängeszon" (också kallad "reverszon" så måste man
 veta vilken zon det är och testa det format det har i DNS. En baklängeszon får
 man genom att vända IP-adressen och lägga på ett suffix. För IPv4-adresser

--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -94,15 +94,14 @@ language code instead of `en`. The code must be in lower case. Then
 translate the file using English as the model.
 
 It is important to preserve the structure of the file. There must be a
-table of contents linking to the question plus answer below. The anchor
-names must be "q1" etc and nothing else. There are links in the code
-that assume this model, where the `<a>` tag is just before the heading.
+table of contents linking to the question plus answer below. The header
+of the answer must start with `####` and then `<span id="q1"></span>`.
+The id must be `q1` etc matching the id in the question and nothing else.
 
 ```
 1. [What is Zonemaster?](#q1)
 
-<a name="q1"></a>
-#### 1. What is Zonemaster?
+#### <span id="q1"></span>1. What is Zonemaster?
 ```
 
 ## Adding a new language

--- a/src/app/components/faq/faq.component.css
+++ b/src/app/components/faq/faq.component.css
@@ -1,4 +1,3 @@
-:host ::ng-deep a[name^=q] {
-  position: relative;
-  top: -90px;
+.faq {
+  overflow-anchor: none;
 }

--- a/src/app/components/faq/faq.component.css
+++ b/src/app/components/faq/faq.component.css
@@ -1,4 +1,4 @@
-:host ::ng-deep span[id^=q] {
+.faq span[id^=q] {
   position: relative;
   top: -90px;
 }

--- a/src/app/components/faq/faq.component.css
+++ b/src/app/components/faq/faq.component.css
@@ -1,3 +1,8 @@
+:host ::ng-deep span[id^=q] {
+  position: relative;
+  top: -90px;
+}
+
 .faq {
   overflow-anchor: none;
 }

--- a/src/app/components/faq/faq.component.ts
+++ b/src/app/components/faq/faq.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewChecked, OnDestroy, Inject, LOCALE_ID } from '@angular/core';
+Aimport { Component, OnInit, AfterViewChecked, OnDestroy, Inject, LOCALE_ID } from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { Subscription } from 'rxjs';
@@ -32,10 +32,15 @@ export class FaqComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   ngAfterViewChecked(): void {
-    try {
-      document.querySelector('a[name="' + this.fragment + '"]').scrollIntoView();
+    if (!this.fragment) {
+      return
+    }
+
+    const faqEntry = document.getElementById(this.fragment);
+    if (faqEntry !== null) {
+      faqEntry.scrollIntoView();
       this.fragment = '';
-    } catch (e) {}
+    }
   }
 
   loadFaq(lang) {


### PR DESCRIPTION
## Purpose

HTML files are created from markdown files. The current markdown code puts the anchor in a paragraph before the headline the link should link to. The solution does not create valid HTML. This PR resolves the issue.

## Changes

All FAQ files in `docs/FAQ/gui-faq-*.md`, but no change of content.

## How to test this PR

Links in table of contents should go to the right question.