### PR TITLE
migrate to the new rpcapi methods

### DIFF
--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -245,8 +245,8 @@ export class ResultComponent implements OnInit, OnDestroy {
     if (!this.history) {
       this.alertService.info($localize `History information request is in progress.`);
 
-      this.dnsCheckService.getTestHistory(this.historyQuery).then(data => {
-        this.history = data as any[];
+      this.dnsCheckService.getTestHistory(this.historyQuery).then(({ history }) => {
+        this.history = history as any[];
         if (this.history.length === 0) {
           this.alertService.info($localize `No previous tests found for this domain.`);
         } else {

--- a/src/app/components/run-test/run-test.component.ts
+++ b/src/app/components/run-test/run-test.component.ts
@@ -35,7 +35,7 @@ export class RunTestComponent implements OnInit {
     }
 
   ngOnInit() {
-    this.dnsCheckService.profileNames().then( (res: string[]) => this.profiles = res );
+    this.dnsCheckService.profileNames().then( ({ profiles }) => this.profiles = profiles );
   }
 
   public fetchFromParent([type, domain]) {
@@ -65,16 +65,16 @@ export class RunTestComponent implements OnInit {
 
     const self = this;
 
-    this.dnsCheckService.startDomainTest(data).then(id => {
-      testId = id as string;
+    this.dnsCheckService.startDomainTest(data).then(({ job_id }) => {
+      testId = job_id as string;
       this.showProgressBar = true;
 
       this.titleService.setTitle(`${data['domain']} · Zonemaster`);
 
       const handle = setInterval(() => {
-        self.dnsCheckService.testProgress(testId).then(res => {
+        self.dnsCheckService.testProgress(testId).then(({ progress  }) => {
 
-          self.runTestProgression = parseInt(res as string, 10) as number;
+          self.runTestProgression = parseInt(progress as string, 10) as number;
 
           if (self.runTestProgression === 100) {
             clearInterval(handle);

--- a/src/app/interceptors/mock.interceptor.ts
+++ b/src/app/interceptors/mock.interceptor.ts
@@ -6,7 +6,7 @@ const urls = [
   // Version info
   {
     url: 'https://zonemaster.net/api',
-    body: {jsonrpc: '2.0', id: 1643203570632, method:'version_info', params: {}},
+    body: {jsonrpc: '2.0', id: 1643203570632, method:'system_versions', params: {}},
     method: 'POST',
     json: {jsonrpc: '2.0', id: 1643203570632, result: {zonemaster_engine: 'e2e-test', zonemaster_backend: 'e2e-test'}}
   },
@@ -14,42 +14,42 @@ const urls = [
   // Profile list in option
   {
     url: 'https://zonemaster.net/api',
-    body: {jsonrpc: '2.0', id:1643203351479, method: 'profile_names', params: {}},
+    body: {jsonrpc: '2.0', id:1643203351479, method: 'conf_profiles', params: {}},
     method: 'POST',
-    json: {jsonrpc: '2.0', id: 1643203351479, result: ["default", "test_profile"]}
+    json: {jsonrpc: '2.0', id: 1643203351479, result: { profiles: ["default", "test_profile"] }}
   },
 
   // FR18 - Should display progress bar
   // FR26 - Should display progress bar
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
+    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'job_create', 'params':
       {
         'language':'en', 'domain': 'progress.afNiC.Fr', 'profile': 'default',
         'nameservers': [], 'ds_info': []
       }
     },
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572254767685, 'result': '2005cf23e9fb24b6'}
+    json: {jsonrpc: '2.0', id: 1572254767685, result: { job_id: '2005cf23e9fb24b6' } }
   },
 
   // FR19 - Should display progress bar when we add a NS name
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
+    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'job_create', 'params':
       {
         'language':'en', 'domain': 'progress.afNiC.Fr', 'profile': 'default',
         'nameservers': [{"ns": "ns1.nic.fr"}], 'ds_info': []
       }
     },
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572254767685, 'result': '2005cf23e9fb24b6'}
+    json: {jsonrpc: '2.0', id: 1572254767685, result: {job_id: '2005cf23e9fb24b6' }}
   },
 
   // FR19 - should NOT display progress bar when we add a NS ip
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
+    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'job_create', 'params':
       {
         'language':'en', 'domain': 'progress.afNiC.Fr', 'profile': 'default',
         'nameservers': [{"ns":"", "ip": "192.134.4.1"}], 'ds_info': []
@@ -57,8 +57,8 @@ const urls = [
     },
     method: 'POST',
     json: {
-      "jsonrpc": "2.0",
-      "error": {
+      jsonrpc: "2.0",
+      error: {
         "message": "Invalid method parameter(s).",
         "code": "-32602",
         "data": [
@@ -75,7 +75,7 @@ const urls = [
   // FR20 - should display progress bar when we add a DS entry and launch a test
   {
     url: 'https://zonemaster.net/api',
-    body:{'jsonrpc': '2.0', 'id': 1572277567967, 'method': 'start_domain_test', 'params':
+    body:{'jsonrpc': '2.0', 'id': 1572277567967, 'method': 'job_create', 'params':
       {
         'language':'en', 'domain': 'progress.afNiC.Fr', 'profile': 'default',
         'nameservers': [], 'ds_info': [{
@@ -87,7 +87,7 @@ const urls = [
       }
     },
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572277567967, 'result': '2005cf23e9fb24b6'}
+    json: {jsonrpc: '2.0', id: 1572277567967, result: { job_id: '2005cf23e9fb24b6' }}
   },
 
   // FR18 - Should display progress bar
@@ -96,9 +96,9 @@ const urls = [
   // FR26 - Should display progress bar
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254972236, 'method': 'test_progress', 'params': {'test_id': '2005cf23e9fb24b6'}},
+    body: {'jsonrpc': '2.0', 'id': 1572254972236, 'method': 'job_status', 'params': {'test_id': '2005cf23e9fb24b6'}},
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572254972236, 'result': 50}
+    json: {'jsonrpc': '2.0', 'id': 1572254972236, 'result': { progress: 50 }}
   },
 
 
@@ -106,49 +106,49 @@ const urls = [
   // FR22 - Should display full messages
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
+    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'job_create', 'params':
       {
         'language':'en', 'domain': 'results.afNiC.Fr', 'profile': 'default',
         'nameservers': [], 'ds_info': []
       }
     },
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572254767685, 'result': '226f6d4f44ae3f80'}
+    json: {jsonrpc: '2.0', id: 1572254767685, result: { job_id: '226f6d4f44ae3f80' }}
   },
 
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
+    body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'job_create', 'params':
       {
         'language':'en', 'domain': 'empty-results.afNiC.Fr', 'profile': 'default',
         'nameservers': [], 'ds_info': []
       }
     },
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572254767685, 'result': 'a0fbcbf6c5ff5842'}
+    json: {jsonrpc: '2.0', id: 1572254767685, result: { job_id: 'a0fbcbf6c5ff5842' }}
   },
 
   // FR21 - Should display summary
   // FR22 - Should display full messages
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254972236, 'method': 'test_progress', 'params': {'test_id': '226f6d4f44ae3f80'}},
+    body: {'jsonrpc': '2.0', 'id': 1572254972236, 'method': 'job_status', 'params': {'test_id': '226f6d4f44ae3f80'}},
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572254972236, 'result': 100}
+    json: {'jsonrpc': '2.0', 'id': 1572254972236, 'result': { progress: 100 }}
   },
 
 
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254972236, 'method': 'test_progress', 'params': {'test_id': 'a0fbcbf6c5ff5842'}},
+    body: {'jsonrpc': '2.0', 'id': 1572254972236, 'method': 'job_status', 'params': {'test_id': 'a0fbcbf6c5ff5842'}},
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572254972236, 'result': 100}
+    json: {'jsonrpc': '2.0', 'id': 1572254972236, 'result': { progress: 100 }}
   },
 
 
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254972327, 'method': 'get_test_results', 'params': {'id': 'a0fbcbf6c5ff5842', 'language': 'en'}},
+    body: {'jsonrpc': '2.0', 'id': 1572254972327, 'method': 'job_results', 'params': {'id': 'a0fbcbf6c5ff5842', 'language': 'en'}},
     method: 'POST',
     json: {'jsonrpc': '2.0', 'id': 1572254972327, 'result': {
         'params': {'profile' : 'default', 'priority': 10, 'ipv6': true, 'ipv4': true, 'client_id': 'Zonemaster GUI',
@@ -168,7 +168,7 @@ const urls = [
   // FR25 - Should open a modal that contains four export possibilities
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572254972327, 'method': 'get_test_results', 'params': {'id': '226f6d4f44ae3f80', 'language': 'en'}},
+    body: {'jsonrpc': '2.0', 'id': 1572254972327, 'method': 'job_results', 'params': {'id': '226f6d4f44ae3f80', 'language': 'en'}},
     method: 'POST',
     json: {'jsonrpc': '2.0', 'id': 1572254972327, 'result': {
         'params': {
@@ -870,9 +870,9 @@ const urls = [
   // FR25 - Should open a modal that contains four export possibilities
   {
     url: 'https://zonemaster.net/api',
-    body: {'jsonrpc': '2.0', 'id': 1572271917712, 'method': 'get_test_history', 'params': {'offset': 0, 'limit': 100, 'filter': 'all', 'frontend_params': {'domain': 'results.afNiC.Fr'}}},
+    body: {'jsonrpc': '2.0', 'id': 1572271917712, 'method': 'domain_history', 'params': {'offset': 0, 'limit': 100, 'filter': 'all', 'frontend_params': {'domain': 'results.afNiC.Fr'}}},
     method: 'POST',
-    json: {'jsonrpc': '2.0', 'id': 1572271917712, 'result': [
+    json: {jsonrpc: '2.0', id: 1572271917712, result: { history: [
       {'overall_result': 'error', 'created_at': '2019-10-28T09:24:57Z', 'creation_time': '2019-10-28 09:42:42.432378', 'id': '293f626579274f18'},
       {'overall_result': 'ok', 'created_at': '2019-10-28T09:24:57Z', 'creation_time': '2019-10-28 09:24:57.395431', 'id': '84bfac6ae74d0e62'},
       {'overall_result': 'ok', 'created_at': '2019-10-24T07:49:48Z', 'creation_time': '2019-10-24 07:49:48.079617', 'id': 'efe0931716b0068c'},
@@ -898,7 +898,7 @@ const urls = [
       {'overall_result': 'ok', 'created_at': '2019-10-23T14:52:56Z', 'creation_time': '2019-10-23 14:52:56.823486', 'id': '497ce5549e80d6d1'},
       {'overall_result': 'ok', 'created_at': '2019-10-23T14:39:25Z', 'creation_time': '2019-10-23 14:39:25.259204', 'id': '470e62da84dcbd16'},
       {'overall_result': 'error', 'created_at': '2019-10-23T14:26:35Z', 'creation_time': '2019-10-23 14:26:35.853106', 'id': '9b8e25c35dc365ac'}
-    ]}
+    ] }}
   },
 ];
 

--- a/src/app/services/dns-check.service.ts
+++ b/src/app/services/dns-check.service.ts
@@ -53,39 +53,40 @@ export class DnsCheckService {
 
   // API Implementation from https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md
   public versionInfo() {
-    return this.RPCRequest('version_info', {}, false);
+    return this.RPCRequest('system_versions', {}, false);
   }
 
   public profileNames() {
-    return this.RPCRequest('profile_names', {}, false);
+    return this.RPCRequest('conf_profiles', {}, false);
   }
 
   public startDomainTest(data) {
-    return this.RPCRequest('start_domain_test', {
+    return this.RPCRequest('job_create', {
       language: this.locale,
       ...data
     });
   }
 
   public testProgress(testId) {
-    return this.RPCRequest('test_progress', {'test_id': testId}, false);
+    return this.RPCRequest('job_status', {'test_id': testId}, false);
   }
 
   public getTestResults(testId: string) {
-    return this.RPCRequest('get_test_results', { id: testId, language: this.locale }, false);
+    return this.RPCRequest('job_results', { id: testId, language: this.locale }, false);
   }
 
   public getTestHistory(data, offset = 0, limit = 100, filter = 'all') {
     const domain = data["domain"];
-    return this.RPCRequest('get_test_history', {
+    return this.RPCRequest('domain_history', {
       offset,
       limit,
       filter,
-      'frontend_params': {domain}}, false);
+      frontend_params: { domain },
+    }, false);
   }
 
   public fetchFromParent(domain) {
-    return this.RPCRequest('get_data_from_parent_zone', {
+    return this.RPCRequest('lookup_delegation_data', {
       language: this.locale,
       domain: domain
     }, false);


### PR DESCRIPTION
## Purpose

Migrate to new RPCAPI methods.

## Context

Zonemaster Backend introduced new RPCAPI methods to replace the current
ones that are being deprecated. Most changes are renaming the methods
and encapsulating results in objects.

## Changes

Change of methods name
* version_info -> system_versions
* profile_names -> conf_profiles
* start_domain_test -> job_create
* test_progress -> job_status
* get_test_results -> job_results
* get_test_history -> domain_history
* get_data_from_parent_zone -> lookup_delegation_data

Methods that return a object but were not before:
* conf_profiles -> { profiles }
* job_create -> { job_id }
* job_status -> { progress }
* domain_history -> { history }

## How to test this PR

1. Set a custom public profile in backend
2. Check that the GUI displays the correct list of profiles
3. Query for delegation data, NS and DS, using the GUI advanced options
4. Create a new test, check that the progress bar is correctly updated, and result correctly fetched
5. Query for tests history