### PR TITLE
fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Zonemaster Web GUI [![Build Status](https://travis-ci.org/zonemaster/zonemaster-gui.svg?branch=master)](https://travis-ci.org/zonemaster/zonemaster-gui)
+Zonemaster Web GUI [![Build Status](https://app.travis-ci.com/zonemaster/zonemaster-gui.svg?branch=master)](https://app.travis-ci.com/zonemaster/zonemaster-gui)
 ==========
 
 ### Purpose


### PR DESCRIPTION
## Purpose

Fix build status badge.

## Context

When travis changed its domain the links to the image and build were not changed.

## Changes

Change link to status image and build logs. 

## How to test this PR

\-
