### PR TITLE
Fix documentation links in FAQ

### DIFF
--- a/docs/FAQ/gui-faq-da.md
+++ b/docs/FAQ/gui-faq-da.md
@@ -7,7 +7,7 @@ Zonemaster
 4. [Zonemaster rapporterer advarsler/fejl på mit domænenavn, hvad betyder det?](#q4)
 5. [Hvordan kan Zonemaster skelne mellem, hvad der er rigtigt og forkert?](#q5)
 6. [Understøtter Zonemaster IPv6?](#q6)
-7. [Understøtter Zonemaster DNSSEC?](#q7) 
+7. [Understøtter Zonemaster DNSSEC?](#q7)
 8. [Hvad gør Zonemaster forkellig fra andre tilsvarende test-værktøjer?](#q8)
 9. [Zonemaster og privatliv](#q9)
 10. [Hvorfor kan jeg ikke teste mit domænenavn?](#q10)
@@ -25,7 +25,7 @@ Zonemaster består af tre grundlæggende moduler:
 
   1. Motor (Koden der udfører alle DNS-tests),
   2. Kommandolinjeinterface (CLI),
-  3. En server, der giver dig mulighed for at køre zonemaster-test og 
+  3. En server, der giver dig mulighed for at køre zonemaster-test og
   gemme resultater ved hjælp af en JSON-RPC API,
   4. Webinterface.
 
@@ -50,7 +50,7 @@ testresultater, der ikke "lyser grønt" på egne domænenavne.
 #### <span id="q4"></span>4. Zonemaster rapporterer advarsler/fejl på mit domænenavn, hvad betyder det?
 Det kommer an på hvilke advarsler/fejl, der rapporteres.
 Hver test er ledsaget af en eller flere meddelelser, der beskriver de fundne problemer.
-Du kan også få yderligere indsigt om hver test fra dokumentet [Defined Test Cases] 
+Du kan også få yderligere indsigt om hver test fra dokumentet [Defined Test Cases]
 
 #### <span id="q5"></span>5. Hvordan kan Zonemaster skelne mellem, hvad der er rigtigt og forkert?
 Zonemasters vurdering er primært baseret på DNS-standarderne som defineret i [RFCs].
@@ -145,14 +145,14 @@ skal du indtaste den i det format, den har i DNS, f.eks.:
 
   - 3.2.1.in-addr.arpa
   - 6.0.1.0.0.2.ip6.arpa
-  
+
 [AFNIC]:                                 https://www.afnic.fr/en/
-[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases
 [spørgsmål 12]:                          #q12
 [spørgsmål 13]:                          #q13
 [RFCs]:                                  https://www.ietf.org/standards/rfcs/
-[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md
 [The Swedish Internet Foundation]:       https://internetstiftelsen.se/en/
-[Using The CLI]:                         https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md
+[Using The CLI]:                         https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md
 [Zonemaster.net]:                        https://zonemaster.net/
 [zonemaster-users@lists.iis.se]:         mailto:zonemaster-users@lists.iis.se

--- a/docs/FAQ/gui-faq-en.md
+++ b/docs/FAQ/gui-faq-en.md
@@ -61,7 +61,7 @@ It also bases its judgement on DNS best practices, which can be more loosely def
 All Zonemaster tests are defined in [Test Case Specifications][Defined Test Cases]
 in which the references to the standard documents for that test case are found.
 
-The descriptions of message levels such as *notice*, *warning* and *error* are found 
+The descriptions of message levels such as *notice*, *warning* and *error* are found
 in [Severity Level Definitions].
 
 Sometimes there are different interpretations of the standards or opinions on what is best practice,
@@ -158,12 +158,12 @@ Examples:
   - For IPv6 prefix '2001:db8::/32': 8.b.d.0.1.0.0.2.ip6.arpa
 
 [AFNIC]:                                 https://www.afnic.fr/en/
-[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases
 [Question 12]:                           #q12
 [Question 13]:                           #q13
 [RFCs]:                                  https://www.ietf.org/standards/rfcs/
-[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md
 [The Swedish Internet Foundation]:       https://internetstiftelsen.se/en/
-[Using The CLI]:                         https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md
+[Using The CLI]:                         https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md
 [Zonemaster.net]:                        https://zonemaster.net/
 [zonemaster-users@lists.iis.se]:         mailto:zonemaster-users@lists.iis.se

--- a/docs/FAQ/gui-faq-es.md
+++ b/docs/FAQ/gui-faq-es.md
@@ -33,7 +33,7 @@ Consiste de varios componentes:
 
 Cuando un nombre de dominio (tal como "zonemaster.net") es enviado a Zonemaster (usando la CLI o
 GUI), este verificará el estado de salud general del nombre de dominio con
-una serie de pruebas. 
+una serie de pruebas.
 Las distintas pruebas realizadas por Zonemaster están documentadas en el
 documento de [Definición de Casos de Pruebas] (en inglés).
 
@@ -188,13 +188,13 @@ Ejemplos:
 
 
 [AFNIC]:                                   https://www.afnic.fr/en/
-[Documento de Requerimientos de Pruebas]:  https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
-[Definición de Casos de Pruebas]:          https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Documento de Requerimientos de Pruebas]:  https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases
+[Definición de Casos de Pruebas]:          https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases
 [Pregunta 12]:                             #q12
 [Pregunta 13]:                             #q13
 [RFCs]:                                    https://www.ietf.org/standards/rfcs/
-[Definiciones de Nivel de Gravedad]:       https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[Definiciones de Nivel de Gravedad]:       https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md
 [The Swedish Internet Foundation]:         https://internetstiftelsen.se/en/
-[Usando La CLI]:                           https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md
+[Usando La CLI]:                           https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md
 [Zonemaster.net]:                          https://zonemaster.net/
 [zonemaster-users@lists.iis.se]:           mailto:zonemaster-users@lists.iis.se

--- a/docs/FAQ/gui-faq-fi.md
+++ b/docs/FAQ/gui-faq-fi.md
@@ -93,13 +93,13 @@ Zonemaster lähettää useita DNS-kyselyitä verkkotunnuksen nimipalvelimille se
 Zonemasterin graafinen käyttöliittymä ei näytä lähetettyjä kyselyjä, vain CLI rajapinta voi näyttää lähetetyt kyselyt.
 Jos haluat nähdä tällaisia kyselyitä, sinun on asennettava paikallisesti toimiva minimaalinen Zonemaster-instanssi, jossa on sekä Engine- että CLI-komponentit (saatavilla on myös Docker image).
 Lähetetyt kyselyt voidaan näyttää käyttämällä 'DEBUG'-tason vaihtoehtoa. Varoituksena, tulokset voivat olla aika raskaita.  Lisätietoja on kohdassa [CLI:n käyttäminen].
-Tätä vaihtoehtoa voi suositella vain teknisesti edistyneille käyttäjille. 
+Tätä vaihtoehtoa voi suositella vain teknisesti edistyneille käyttäjille.
 
 #### <span id="q12"></span>12. Mikä on delegoimattoman verkkotunnuksen testi?
 
-Delegoimaton verkkotunnustesti tehdään verkkotunnukselle, jota ei tarvitse välttämättä olla julkaistu DNS:ssä. Se voi olla varsin hyödyllistä, jos aiot siirtää verkkotunnuksesi verkkotunnusvälittäjältä toiselle. 
-Jos esimerkiksi verkkotunnus esimerkki.se aiotaan siirtää nimipalvelimelta &#39;ns.nic.se&#39; nimipalvelimelle &#39;ns.iis.se&#39;, voit tehdä verkkotunnukselle (esimerkki.se) delegoimattoman 
-verkkotunnustestin sillä nimipalvelimella, johon aiot siirtää sen (ns.iis.se), ennen kuin toteutat siirron. Jos testi näyttää vihreää valoa, voit olla melko varma siitä, että verkkotunnuksesi uudessa 
+Delegoimaton verkkotunnustesti tehdään verkkotunnukselle, jota ei tarvitse välttämättä olla julkaistu DNS:ssä. Se voi olla varsin hyödyllistä, jos aiot siirtää verkkotunnuksesi verkkotunnusvälittäjältä toiselle.
+Jos esimerkiksi verkkotunnus esimerkki.se aiotaan siirtää nimipalvelimelta &#39;ns.nic.se&#39; nimipalvelimelle &#39;ns.iis.se&#39;, voit tehdä verkkotunnukselle (esimerkki.se) delegoimattoman
+verkkotunnustestin sillä nimipalvelimella, johon aiot siirtää sen (ns.iis.se), ennen kuin toteutat siirron. Jos testi näyttää vihreää valoa, voit olla melko varma siitä, että verkkotunnuksesi uudessa
 kodissa on kaikki kunnossa. Verkkotunnuksen määrityksissä voi kuitenkin olla virheitä, joita testi ei löydä.
 
 #### <span id="q13"></span>13. Voinko testata DS-tietueet ennen niiden julkaisua?
@@ -114,13 +114,13 @@ Jotta voisit testata käänteisverkkotunnuksen (reverse zone), sinun on tiedett�
 
   - 3.2.1.in-addr.arpa
   - 6.0.1.0.0.2.ip6.arpa
-  
+
 [AFNIC]:                                 https://www.afnic.fr/en/
-[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases
 [Internetstiftelsen]:                    https://internetstiftelsen.se/
 [Question 12]:                           #q12
 [Question 13]:                           #q13
-[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md
 [Test Requirements document]:            https://github.com/zonemaster/zonemaster/blob/master/docs/requirements/TestRequirements.md
 [zonemaster-users@lists.iis.se]:         mailto:zonemaster-users@lists.iis.se
 [www.zonemaster.net]:                    https://www.zonemaster.net/

--- a/docs/FAQ/gui-faq-fr.md
+++ b/docs/FAQ/gui-faq-fr.md
@@ -136,7 +136,7 @@ l'utilisateur ne sont conservés dans la base de données. L'initiateur d'un
 test ne peut pas être retrouvé à partir des informations dans la base de
 données.
 
- #### <span id="q10"></span>10. Pourquoi mon nom de domaine n'a-t-il pas pu être testé ?
+#### <span id="q10"></span>10. Pourquoi mon nom de domaine n'a-t-il pas pu être testé ?
 
 Il y a plusieurs possibilités :
 
@@ -203,12 +203,12 @@ Exemples :
   - Pour le préfixe IPv6 « 2001:db8::/32 » : 8.b.d.0.1.0.0.2.ip6.arpa.
 
 [Afnic]:                                 https://www.afnic.fr/fr/
-[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases
 [Question 12]:                           #q12
 [Question 13]:                           #q13
 [RFC]:                                   https://www.ietf.org/standards/rfcs/
-[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md
 [The Swedish Internet Foundation]:       https://internetstiftelsen.se/en/
-[Utilisation de l'interface en ligne de commandes]: https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md
+[Utilisation de l'interface en ligne de commandes]: https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md
 [Zonemaster.net]:                        https://zonemaster.net/
 [zonemaster-users@lists.iis.se]:         mailto:zonemaster-users@lists.iis.se

--- a/docs/FAQ/gui-faq-nb.md
+++ b/docs/FAQ/gui-faq-nb.md
@@ -112,12 +112,12 @@ Eksempel 1 - reversoppslag for et IPv4-nett: Nettadressen er 194.98.30.0 og gir 
 Eksempel 2 - reversoppslag for et IPv6-nett: Nettadressen er 2001:660:3003::0 og gir reversoppslagssonen 3.0.0.3.0.6.6.0.1.0.0.2.ip6.arpa.
 
 [AFNIC]:                                 https://www.afnic.fr/en/
-[Definierte tester]:                     https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Definierte tester]:                     https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases
 [Spørsmål 12]:                           #q12
 [Spørsmål 13]:                           #q13
 [RFCs]:                                  https://www.ietf.org/standards/rfcs/
-[Definisjoner av alvorlighetsgrad]:      https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[Definisjoner av alvorlighetsgrad]:      https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md
 [Internetstiftelsen]:                    https://internetstiftelsen.se/en/
-[Bruk av CLI]:                           https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md
+[Bruk av CLI]:                           https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md
 [Zonemaster.net]:                        https://zonemaster.net/
 [zonemaster-users@lists.iis.se]:         mailto:zonemaster-users@lists.iis.se

--- a/docs/FAQ/gui-faq-sv.md
+++ b/docs/FAQ/gui-faq-sv.md
@@ -182,14 +182,13 @@ Exempel:
 
 
 [AFNIC]:                                 https://www.afnic.fr/en/
-[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Defined Test Cases]:                    https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases
 [Question 12]:                           #q12
 [Question 13]:                           #q13
 [RFCs]:                                  https://www.ietf.org/standards/rfcs/
-[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[Severity Level Definitions]:            https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md
 [The Swedish Internet Foundation]:       https://internetstiftelsen.se/en/
-[Using The CLI]:                         https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md
+[Using The CLI]:                         https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md
 [Zonemaster.net]:                        https://zonemaster.net/
 [zonemaster-users@lists.iis.se]:         mailto:zonemaster-users@lists.iis.se
 [Wikipedia#Engelska#RFC]:                https://en.wikipedia.org/wiki/Request_for_Comments
-


### PR DESCRIPTION
## Purpose

Fix broken links in FAQ.

## Context

Since v2023.1, the documentation architecture has changed. The links in the FAQ have not been updated.

## Changes

* Update links pointing to the documentation.
* Fix broken heading in French FAQ.
* Remove useless trailing spaces.

## How to test this PR

* Check that the FAQ is correctly rendered.
* Check that the links are working.
