### PR TITLE
Fix unspecified

### DIFF
--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -188,7 +188,7 @@
       </h3>
       <div id="module-{{ module.name }}" role="region" [attr.aria-labelledby]="'control-module-' + module.name">
         <section class="testcase" *ngFor="let testcase of module.testcases" [class.collapsed]="isCollapsed[module.name]">
-          <header class="{{testcase.level}}" *ngIf="testcase.id != 'UNSPECIFIED'">
+          <header class="{{testcase.level}}" *ngIf="testcase.id.toUpperCase() != 'UNSPECIFIED'">
             <h4>
               <button
                 type="button"

--- a/src/app/components/result/result.component.ts
+++ b/src/app/components/result/result.component.ts
@@ -222,10 +222,10 @@ export class ResultComponent implements OnInit, OnDestroy {
     for (const module in modulesMap) {
       modulesMap[module].testcases.sort((testcase1, testcase2) => {
         // sort messages by descending severity level, unspecified messages always on top
-        if (testcase1.id == 'UNSPECIFIED') {
+        if (testcase1.id.toUpperCase() == 'UNSPECIFIED') {
           return 1;
         }
-        if (testcase2.id == 'UNSPECIFIED') {
+        if (testcase2.id.toUpperCase() == 'UNSPECIFIED') {
           return 1;
         }
         return this.severityLevels[testcase2.level] - this.severityLevels[testcase1.level];
@@ -242,7 +242,11 @@ export class ResultComponent implements OnInit, OnDestroy {
       }
     }
 
-    this.isCollapsed['UNSPECIFIED'] = false;
+    for (const testCase in this.isCollapsed) {
+      if (testCase.toUpperCase() == 'UNSPECIFIED') {
+        this.isCollapsed[testCase] = false;
+      }
+    }
 
     return testCasesCount;
   }


### PR DESCRIPTION
## Purpose

Fix the handling of unspecified messages following https://github.com/zonemaster/zonemaster-engine/pull/1302

## Context

based on #434
https://github.com/zonemaster/zonemaster-engine/pull/1302

## Changes

The unspecified messages are displayed above other messages and not collapsed, regardless of the case of "Unspecified".

Relevant commit : 6a2a7ad9f145d2a88a6760793516e82031c0751f

## How to test this PR

Consult a test result of a domain tested after and before the change in https://github.com/zonemaster/zonemaster-engine/pull/1302.

![Screenshot of the Basic and Address module in GUI result showing unspecified log entries above entries from test cases](https://github.com/zonemaster/zonemaster-gui/assets/19394895/ecc11092-3e89-4358-89ea-58627abac034)

What this PR fixes:

![Screenshot of the Basic and Address module in GUI where unspecified log entries are under an UNSPECIFIED heading](https://github.com/zonemaster/zonemaster-gui/assets/19394895/bb29ec80-291a-48c2-8225-f0e9a70d4c73)
