### PR TITLE
Update Spanish translation (FAQ mostly)

### DIFF
--- a/src/locale/messages.es.xlf
+++ b/src/locale/messages.es.xlf
@@ -226,7 +226,6 @@
       </trans-unit>
       <trans-unit id="cff1428d10d59d14e45edec3c735a27b5482db59" datatype="html">
         <source>Name</source>
-        <target state="new">Ejecutar</target>
         <note priority="1" from="description">form label</note>
       </trans-unit>
       <trans-unit id="60a3620e64219321c8b50da502a404e9cef901ef" datatype="html">
@@ -326,7 +325,7 @@
         <source>
           <x id="INTERPOLATION" equiv-text="rogress bar."/>
         </source>
-        <target state="new">
+        <target state="translated">
           <x id="INTERPOLATION" equiv-text="rogress bar."/>
         </target>
       </trans-unit>
@@ -338,6 +337,7 @@
       </trans-unit>
       <trans-unit id="28c3ac557314fb526258cf6cbb8912bacb769dd6" datatype="html">
         <source>What is Zonemaster?</source>
+        <target state="translated">¿Qué es Zonemaster?</target>
       </trans-unit>
       <trans-unit id="02de72ecb8a333fc270d81e7979f5f16ad51bd15" datatype="html">
         <source>When a domain name is sent to Zonemaster for testing, Zonemaster investigates the state of the domain name from the top to the bottom of the DNS tree. This is usually done by examining DNS data from the root, &apos;.&apos;, to the Top-Level Domain (TLD) for that domain name, like &apos;.net&apos;, and then finally through the DNS servers that contain authoritative information about the specified domain name.</source>
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="08d618cac3fb7211daea88b1f94346e12a66db93" datatype="html">
         <source>More information on undelegated test:</source>
-        <target state="new">More information on undelegated test:</target>
+        <target state="translated">Más información en la prueba no-delegada:</target>
         <note priority="1" from="description">form info</note>
       </trans-unit>
       <trans-unit id="2ab292382051ee24f6ab19bc30bbc9441b87a0c0" datatype="html">
@@ -407,11 +407,11 @@
       </trans-unit>
       <trans-unit id="aaf16bc892257c68570faaece1ae7c328d4ea574" datatype="html">
         <source>Give your domain name a complete checkup! <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Zonemaster helps you assess how your domain name is doing.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/></source>
-        <target state="new">Give your domain name a complete checkup! <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Zonemaster helps you assess how your domain name is doing.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/></target>
+        <target state="translated">¡Dele a su dominio una revisión completa! <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Zonemaster le ayuda a evaluar cómo lo está haciendo su nombre de dominio.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/></target>
       </trans-unit>
       <trans-unit id="990eafebba6d6aa5a9d04f33005ee4bf01e83a20" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Zonemaster performs many tests<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, such as checking DNSSEC signatures, or that different hosts can be accessed and that IP addresses are valid. This is all to make sure that your domain name runs as smoothly as possible.</source>
-        <target state="new"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Zonemaster performs many tests<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, such as checking DNSSEC signatures, or that different hosts can be accessed and that IP addresses are valid. This is all to make sure that your domain name runs as smoothly as possible.</target>
+        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Zonemaster realiza muchas pruebas<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, por ejemplo revisar las firmas DNSSEC, o que los distintos servidores sean alcanzables, y que todas las direcciones IP sean válidas. Todo esto para asegurar que su nombre de dominio funcione tan bien como sea posible.</target>
       </trans-unit>
       <trans-unit id="8db253c0a29b5f46dd1ed8f52bdce7b2db5f0f06" datatype="html">
         <source>Frequently asked questions</source>
@@ -435,77 +435,77 @@
       </trans-unit>
       <trans-unit id="8b10e6ae872a96b58fbcd7261cc90f226798d756" datatype="html">
         <source>What is Zonemaster?</source>
-        <target state="new">What is Zonemaster?</target>
+        <target state="translated">¿Qué es Zonemaster?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="cc001ff8c20d30dd726f8c27e010f3f97963327a" datatype="html">
         <source>Who is behind Zonemaster?</source>
-        <target state="new">Who is behind Zonemaster?</target>
+        <target state="translated">¿Quién está detrás de Zonemaster?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="2c2546090ea5fa029ce31f5d5390dce114a5c9a8" datatype="html">
         <source>Zonemaster is a joint project between <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registry of &apos;.fr&apos; TLD and several other TLDs, e.g. &apos;.re&apos;, &apos;.pm&apos;, &apos;.tf&apos;, &apos;.wf&apos;, &apos;.yt&apos; and &apos;.paris&apos;) and <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registry of &apos;.se&apos; and &apos;.nu&apos; TLDs).</source>
-        <target state="new">Zonemaster is a joint project between <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registry of &apos;.fr&apos; TLD and several other TLDs, e.g. &apos;.re&apos;, &apos;.pm&apos;, &apos;.tf&apos;, &apos;.wf&apos;, &apos;.yt&apos; and &apos;.paris&apos;) and <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registry of &apos;.se&apos; and &apos;.nu&apos; TLDs).</target>
+        <target state="translated">Zonemaster es un proyecto conjunto entre <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registro para el TLD .fr y varios otros, por ejemplo .re, .pm, .tf, .wf, .yt y .paris) y <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registro de los TLDs .se y .nu).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="e2bf4547393abb2e5e4c77cfaaeb79e8f85a541c" datatype="html">
         <source>How can Zonemaster help me?</source>
-        <target state="new">How can Zonemaster help me?</target>
+        <target state="translated">¿Cómo me puede ayudar Zonemaster?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="fdca9ec2c5041bd0c8bc200d1bb56ace1920f8f2" datatype="html">
         <source>The Zonemaster tool could help different kind of users:</source>
-        <target state="new">The Zonemaster tool could help different kind of users:</target>
+        <target state="translated">La herramienta Zonemaster está orientada a dos categorías de usuarios:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="90e55bb71b57ffa3d778c6a9e676c505d4b897cb" datatype="html">
         <source>Users who just want to know whether the domain name they own or use have any issues or not.</source>
-        <target state="new">Users who just want to know whether the domain name they own or use have any issues or not.</target>
+        <target state="translated">Usuarios que solo quieren saber si el nombre de dominio que poseen o usan tiene algún problema.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="7f82cd00cb66740b1e8e6695ceb6987d951e38e5" datatype="html">
         <source>Users of the second category should contact their DNS operator in case there are errors or warnings for any test of their domain name.</source>
-        <target state="new">Users of the second category should contact their DNS operator in case there are errors or warnings for any test of their domain name.</target>
+        <target state="translated">Los usuarios de la segunda categoría deberían contactar a sus operadores DNS tan pronto obtengan resultados distintos a &quot;verde&quot; en cualquiera de las pruebas sobre sus nombres de dominio.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="8dbcc14f18696f9d909524ca7364f9988cf901b8" datatype="html">
         <source>What makes Zonemaster different from other DNS zone validating software?</source>
-        <target state="new">What makes Zonemaster different from other DNS zone validating software?</target>
+        <target state="translated">¿Qué hace distinto a Zonemaster de otros software de validación DNS?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="3942f9186d69777597c1fba63f78762033da2ee4" datatype="html">
         <source>Firstly, Zonemaster saves all history from earlier tests based on the tested domain name, which means you can go back to a test you did some time ago and compare it to the test you ran just a moment ago.</source>
-        <target state="new">Firstly, Zonemaster saves all history from earlier tests based on the tested domain name, which means you can go back to a test you did some time ago and compare it to the test you ran just a moment ago.</target>
+        <target state="translated">Primero que todo, Zonemaster guarda toda la historia de pruebas anteriores basadas en el nombre del dominio probado, de tal forma que puedes ir hacia atrás a una prueba que hiciste hace un tiempo, y compararla con la prueba que acabas de hacer hace unos momentos.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="5bad6b87847399d805291b8a8d89a84ef6576c42" datatype="html">
         <source>Lastly, this open source version of Zonemaster was built using modular code which basically means that you can integrate parts of it in your own systems, if you wish. For example, it is quite rare that you would want a complete program just to check for redelegations.</source>
-        <target state="new">Lastly, this open source version of Zonemaster was built using modular code which basically means that you can integrate parts of it in your own systems, if you wish. For example, it is quite rare that you would want a complete program just to check for redelegations.</target>
+        <target state="translated">Por último, esta versión de código abierto de Zonemaster fue construida usando código modular, lo que básicamente significa que puedes integrar partes del software en tus propios sistemas, si así lo quisieras. Por ejemplo, es muy raro que quieras instalar un programa completo para sólo probar redelegaciones.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="f3a7aab6d6b07e6db0c1ba7e4b88f53430d5ce81" datatype="html">
         <source>How can Zonemaster distinguish between what is right and wrong?</source>
-        <target state="new">How can Zonemaster distinguish between what is right and wrong?</target>
+        <target state="translated">¿Cómo puede juzgar Zonemaster qué está bien y qué está mal?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="7d2a11619babe460976bf5e38e5e920cbbf968cd" datatype="html">
         <source>Sometimes there are different interpretations of the standards or opinions on what is best practice, and the Zonemaster team is always open to input. If you think we have made a mistake in our judgement please do not hesitate to send us an email at <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:zonemaster-users@lists.iis.se&quot;&gt;"/>zonemaster-users@lists.iis.se<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (moderated mailing list) with a link to your test result and an explanation as to why you think it shows something that you consider incorrect.</source>
-        <target state="new">Sometimes there are different interpretations of the standards or opinions on what is best practice, and the Zonemaster team is always open to input. If you think we have made a mistake in our judgement please do not hesitate to send us an email at <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:zonemaster-users@lists.iis.se&quot;&gt;"/>zonemaster-users@lists.iis.se<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (moderated mailing list) with a link to your test result and an explanation as to why you think it shows something that you consider incorrect.</target>
+        <target state="translated">A veces hay distintas interpretaciones de los estándares, u opiniones de lo que es una buena práctica, y el equipo de Zonemaster siempre está abierto a sugerencias. Si crees que hemos cometido un error de criterio, por favor no dudes en enviarnos un email a <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:zonemaster-users@lists.iis.se&quot;&gt;"/>zonemaster-users@lists.iis.se<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (lista de correo moderada) con un enlace al resultado de tu prueba y una explicación por qué crees que muestra algo que consideres incorrecto.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="076e3c1beadaa4e6ba7989124471ab3d14bbc523" datatype="html">
         <source>What kind of queries does Zonemaster generate?</source>
-        <target state="new">What kind of queries does Zonemaster generate?</target>
+        <target state="translated">¿Qué tipo de consultas genera Zonemaster?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="56c265f73e958064c7bcfee6e566516e03066c1a" datatype="html">
         <source>Zonemaster send multiple DNS queries to the name servers hosting the domain name being tested and also to the name servers hosting the parent zone of that domain name.</source>
-        <target state="new">Zonemaster send multiple DNS queries to the name servers hosting the domain name being tested and also to the name servers hosting the parent zone of that domain name.</target>
+        <target state="translated">Zonemaster envía múltiples consultas DNS a los servidores de nombre que hospedan al nombre de dominio que se está probando, y también a los servidores de nombre que hospedan la zona padre del nombre de dominio.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="441b723a458aa167da55ee24002ef0a38ac81a96" datatype="html">
         <source>Zonemaster and privacy</source>
-        <target state="new">Zonemaster and privacy</target>
+        <target state="translated">Zonemaster y privacidad</target>
         <note priority="1" from="description">faq response</note>
       </trans-unit>
       <trans-unit id="0c82e2cf51eabccbfebc06f15066ea674e03b5ba" datatype="html">
@@ -515,122 +515,122 @@
       </trans-unit>
       <trans-unit id="87b80f57df949b82582bceaf5fd07567657d83a3" datatype="html">
         <source>How come my domain name cannot be tested?</source>
-        <target state="new">How come my domain name cannot be tested?</target>
+        <target state="translated">¿Por qué no puedo probar mi nombre de dominio?</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="67269fee7f44c79618ab1c709d8dd53949545984" datatype="html">
         <source>There are several possibilities:</source>
-        <target state="new">There are several possibilities:</target>
+        <target state="translated">Puede haber varias posibilidades:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="5ade768ec4a2e175bdcc18687d04ef22efa461da" datatype="html">
         <source>Your domain name is not yet delegated.</source>
-        <target state="new">Your domain name is not yet delegated.</target>
+        <target state="translated">Su nombre de dominio aún no está delegado.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="455236713205c5803658d6e4c2735241a62a06a5" datatype="html">
         <source>Your domain name is not reachable from public Internet.</source>
-        <target state="new">Your domain name is not reachable from public Internet.</target>
+        <target state="translated">Su nombre de dominio no es alcanzable desde la Internet pública.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="2c3a34d5c350d025523503260d7b7fd2be5bd297" datatype="html">
         <source>Zonemaster can only test what is called a DNS zone (e.g. &apos;zonemaster.net&apos;) and not host names (e.g. &apos;www.zonemaster.net&apos;)</source>
-        <target state="new">Zonemaster can only test what is called a DNS zone (e.g. &apos;zonemaster.net&apos;) and not host names (e.g. &apos;www.zonemaster.net&apos;)</target>
+        <target state="translated">Zonemaster solo puede probar una zona DNS (por ej. &apos;zonemaster.net&apos;) y no nombres de host (por ej. &apos;www.zonemaster.net&apos;).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="eb42d0a7485a530b74a81467195b779cdb447607" datatype="html">
         <source>There is a 10 minutes protection between consecutive tests for a given domain name (with same test parameters). Running a test within that window will instead show the last available test for that domain name (and parameters).</source>
-        <target state="new">There is a 10 minutes protection between consecutive tests for a given domain name (with same test parameters). Running a test within that window will instead show the last available test for that domain name (and parameters).</target>
+        <target state="translated">Existe una protección de 10 minutos entre pruebas consecutivas por un nombre de dominio determinado (con los mismos parámetros de pruebas). Al ejecutar una prueba dentro de esa ventana de tiempo, se mostrará el último resultado que se se obtuvo para ese nombre de dominio (con los mismos parámetros).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="3fa205532eeda5bef22a1c0268e823b691682f2e" datatype="html">
         <source>You have misspelled your domain name.</source>
-        <target state="new">You have misspelled your domain name.</target>
+        <target state="translated">Ha escrito mal su nombre de dominio.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="017a18b1b16fe7d0fbcb10ff395b3dd8c4ae6a15" datatype="html">
         <source>Zonemaster returns &quot;Error&quot; or &quot;Warning&quot; for my domain name. What does it mean?</source>
-        <target state="new">Zonemaster returns &quot;Error&quot; or &quot;Warning&quot; for my domain name. What does it mean?</target>
+        <target state="translated">Zonemaster indica &quot;Error&quot; o &quot;Advertencia&quot; en mi dominio. ¿Qué significa?</target>
         <note priority="1" from="description">faq response</note>
       </trans-unit>
       <trans-unit id="42250f7733996b993b937350f4e1cb0df5a60561" datatype="html">
         <source>What is an undelegated domain test?</source>
-        <target state="new">What is an undelegated domain test?</target>
+        <target state="translated">¿Qué es una prueba de dominio no-delegado?</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="e9e0008a5b47b371cc2f592e2b07f7f436f69579" datatype="html">
         <source>An undelegated domain test is a test performed on a domain name that may, or may not, be fully published in the DNS. This can be quite useful if one is going to migrate one&apos;s domain from one registrar to another, e.g., migrate zone &apos;example.com&apos; from the name server &apos;ns.example.com&apos; to the name server &apos;ns.example.org&apos;. In this scenario one could perform an undelegated domain test providing the zone (&apos;example.com&apos;) and the name server you are migrating to (&apos;ns.example.org&apos;) before you migrate your domain. When the results of the test doesn&apos;t show any errors or warnings one can be fairly certain that the domain&apos;s new location is working well. However there might still be other problems in the zone data itself that this test is unaware of.</source>
-        <target state="new">An undelegated domain test is a test performed on a domain name that may, or may not, be fully published in the DNS. This can be quite useful if one is going to migrate one&apos;s domain from one registrar to another, e.g., migrate zone &apos;example.com&apos; from the name server &apos;ns.example.com&apos; to the name server &apos;ns.example.org&apos;. In this scenario one could perform an undelegated domain test providing the zone (&apos;example.com&apos;) and the name server you are migrating to (&apos;ns.example.org&apos;) before you migrate your domain. When the results of the test doesn&apos;t show any errors or warnings one can be fairly certain that the domain&apos;s new location is working well. However there might still be other problems in the zone data itself that this test is unaware of.</target>
+        <target state="translated">Una prueba de dominio no-delegado es una prueba ejecutada sobre un nombre de dominio que puede o no estar completamente publicado en el DNS. Esto es muy útil cuando uno quiere mover un nombre de dominio desde un registrador a otro, por ejemplo al mover la zona example.com desde el servidor de nombres &quot;ns.example.com&quot; al servidor &quot;ns.example.org&quot;. En este escenario, uno podría ejecutar una prueba de dominio no-delegado indicando la zona (example.com) y el servidor de nombres futuro al cual va a mover el dominio (ns.example.org) antes de que muevas el dominio. Cuando obtenga los resultados de las pruebas en verde, uno puede estar suficientemente seguro que la nueva ubicación del dominio está funcionando correctamente. Sin embargo, puede haber otros problemas en los datos de la zona en sí misma, que esta prueba ignora.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="714b9a1e26a0fb83903c47c5861168eb802f14c8" datatype="html">
         <source>Does Zonemaster support IPv6?</source>
-        <target state="new">Does Zonemaster support IPv6?</target>
+        <target state="translated">¿Zonemaster soporta IPv6?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="e202abce3d27b876ce27b42e2c65c4109d902e00" datatype="html">
         <source>Yes. By default Zonemaster will query name servers both over IPv4 and IPv6, unless explicitly configured otherwise. Such configuration is accessible through the &quot;Options&quot; button.</source>
-        <target state="new">Yes. By default Zonemaster will query name servers both over IPv4 and IPv6, unless explicitly configured otherwise. Such configuration is accessible through the &quot;Options&quot; button.</target>
+        <target state="translated">Sí. Por defecto Zonemaster consultará a los servidores de nombre usando IPv4 e IPv6, a menos que sea configurado explícitamente de otra forma. Esta configuración se encuentra en el botón &quot;Opciones&quot;.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="0a5f5612b4d2dfb3a9bf032f9815e6228d0721a6" datatype="html">
         <source>Does Zonemaster verify DNSSEC?</source>
-        <target state="new">Does Zonemaster verify DNSSEC?</target>
+        <target state="translated">¿Zonemaster verifica DNSSEC?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="0874420d71f7584ca97473e73ab7c592f0b30aa8" datatype="html">
         <source>Yes. If DNSSEC is available for a domain name that is tested by Zonemaster, it will be checked automatically.</source>
-        <target state="new">Yes. If DNSSEC is available for a domain name that is tested by Zonemaster, it will be checked automatically.</target>
+        <target state="translated">Sí. En caso que un nombre de dominio que esté en prueba por Zonemaster tenga soporte DNSSEC, será revisado automáticamente.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="e2237b52ebfa3de41c77020cec38616f433af690" datatype="html">
         <source>Can I test the DS records before they are published?</source>
-        <target state="new">Can I test the DS records before they are published?</target>
+        <target state="translated">¿Puedo probar los registros DS antes de ser publicados?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
       <trans-unit id="2e3dcb30f608294a8ca15718a32604ced7555f7a" datatype="html">
         <source>Yes. Use the &quot;Options&quot; button and there add the Delegation Signer (DS) records to be tested. Zonemaster will then use those in the same way as if they were already added in the parent zone.</source>
-        <target state="new">Yes. Use the &quot;Options&quot; button and there add the Delegation Signer (DS) records to be tested. Zonemaster will then use those in the same way as if they were already added in the parent zone.</target>
+        <target state="translated">Sí. Puede utilizar el botón &quot;Opciones&quot; y agregar ahí los registros &quot;Delegation Signer&quot; (DS) que quiera probar. Zonemaster los usará de la misma forma que si hubieran sido obtenidos desde la zona padre.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="794667cd8ae08bd15b1d9943e03f8b2886ee6f65" datatype="html">
         <source>How can I test a &quot;reverse&quot; zone with Zonemaster?</source>
-        <target state="new">How can I test a &quot;reverse&quot; zone with Zonemaster?</target>
+        <target state="translated">¿Cómo puedo probar una zona reversa con Zonemaster?</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="b789969c61b2104694bf51c0d99f6d4865f3bdf6" datatype="html">
         <source>To check a reverse zone with Zonemaster, one first needs to know what the reverse zone is, and enter it in the format it has in the DNS. A reserve zone is obtained by reversing an IP address and adding a suffix. IPv4 addresses use the suffix &quot;in-addr.arpa&quot; while IPv6 addresses use &quot;ip6.arpa&quot;.</source>
-        <target state="new">To check a reverse zone with Zonemaster, one first needs to know what the reverse zone is, and enter it in the format it has in the DNS. A reserve zone is obtained by reversing an IP address and adding a suffix. IPv4 addresses use the suffix &quot;in-addr.arpa&quot; while IPv6 addresses use &quot;ip6.arpa&quot;.</target>
+        <target state="translated">Para revisar una zona &quot;reversa&quot; (también llamada &quot;inversa&quot;) con Zonemaster, lo primero que necesitas es saber qué zona reversa es, e ingresarla en el formato que tiene en el DNS. Una zona reversa se obtiene dando vuelta una dirección IP y agregándole un sufijo. Las direcciones IPv4 usan el sufijo &quot;in-addr.arpa&quot;, mientras que las direcciones IPv6 usan &quot;ip6.arpa&quot;.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="a23358df7e314fa4acf55b527319f91acbb25a81" datatype="html">
         <source>Examples:</source>
-        <target state="new">Examples:</target>
+        <target state="translated">Ejemplos:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="93c29dbaff15d2569875f4e67925d39859eeb465" datatype="html">
         <source>For IPv4 prefix &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa</source>
-        <target state="new">For IPv4 prefix &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa</target>
+        <target state="translated">Para el prefijo IPv4 &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="699eaa999ec82b70f68bf14932cc97ad893a0e0b" datatype="html">
         <source>For IPv6 prefix &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa</source>
-        <target state="new">For IPv6 prefix &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa</target>
+        <target state="translated">Para el prefijo IPv6 &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="56a21bdcd76a6ac5dd60c17f5170b999b63e0ac0" datatype="html">
         <source>Source code</source>
-        <target state="new">Source code</target>
+        <target state="translated">Código fuente</target>
         <note priority="1" from="meaning">footer</note>
       </trans-unit>
       <trans-unit id="0d7a9fc8b4f70faf02a5f9a36e40d0950a1c5ed3" datatype="html">
         <source>Documentation</source>
-        <target state="new">Documentation</target>
+        <target state="translated">Documentación</target>
         <note priority="1" from="meaning">footer</note>
       </trans-unit>
       <trans-unit id="8cb0e28165b27b862dee9ee8e11a527bed59661a" datatype="html">
         <source>https://www.afnic.fr/en/</source>
-        <target state="new">https://www.afnic.fr/en/</target>
+        <target state="translated">https://www.afnic.fr/en/</target>
         <note priority="1" from="description">Afnic link</note>
       </trans-unit>
       <trans-unit id="729754dd19eb9ce0670b0aeb5a6ae60574c2c563" datatype="html">
@@ -680,17 +680,17 @@
       </trans-unit>
       <trans-unit id="521683f96e95e165cd852c6a1850b468b4f49237" datatype="html">
         <source>:</source>
-        <target state="new">:</target>
+        <target state="translated">:</target>
         <note priority="1" from="description">result colon</note>
       </trans-unit>
       <trans-unit id="43f466d9ffc7d0c6590b0f2b10bd60dca832ef61" datatype="html">
         <source>https://internetstiftelsen.se/en/</source>
-        <target state="new">https://internetstiftelsen.se/en/</target>
+        <target state="translated">https://internetstiftelsen.se/en/</target>
         <note priority="1" from="description">IIS link</note>
       </trans-unit>
       <trans-unit id="a7f350306ae4832b697a4992036635dcd3e3d066" datatype="html">
         <source>https://en.wikipedia.org/wiki/Request_for_Comments</source>
-        <target state="new">https://en.wikipedia.org/wiki/Request_for_Comments</target>
+        <target state="translated">https://es.wikipedia.org/wiki/Request_for_Comments</target>
         <note priority="1" from="description">RFC Wikipedia link</note>
       </trans-unit>
       <trans-unit id="5372fde550a1fdc4c86332c79d988bb0554f03b3" datatype="html">
@@ -705,7 +705,7 @@
       </trans-unit>
       <trans-unit id="99a0620d495f0d1ab864174f77a560140c5e214a" datatype="html">
         <source>The descriptions of message levels such as <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>notice<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>warning<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> and <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> are found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Severity Level Definitions<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <target state="new">The descriptions of message levels such as <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>notice<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>warning<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> and <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> are found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Severity Level Definitions<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
+        <target state="translated">Las descripciones de los niveles de mensaje, como <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>información<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>advertencia<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> y <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> se encuentran en <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Definiciones de Nivel de Gravedad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="6d41e759de3c0117413b5a6e5b5cd3f44ecb4676" datatype="html">
@@ -718,64 +718,77 @@
       </trans-unit>
       <trans-unit id="c51835a3345882fb12374bddfd2e4b73e4f69db8" datatype="html">
         <source>Zonemaster is a program designed to help people check, measure and hopefully also understand how the DNS (Domain Name System) works.</source>
+        <target state="translated">Zonemaster es un programa diseñado para ayudar a la gente a revisar, medir y ojalá también entender cómo funciona el DNS (Sistema de Nombres de Dominio).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="11aba2484b1af47b7dcd308237d231d0dd666d65" datatype="html">
         <source>It consists of several components:</source>
+        <target state="translated">Consiste de varios componentes:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="cd1f6944c474bd4875b37226edbe8ed0b802ef1a" datatype="html">
         <source>Engine - a test framework that supports all functionality to perform DNS tests.</source>
+        <target state="translated">&quot;Engine&quot; (Motor) - una arquitectura de pruebas que soporta toda la funcionalidad para realizar pruebas DNS.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="8f95b69eb8b7f2620f2bf39028a754efbb02e17c" datatype="html">
         <source>CLI - a command-line interface to the Engine.</source>
+        <target state="translated">&quot;CLI&quot; - una interfaz de línea de comandos hacia el Engine.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="fdfa7928b51beb9b7143d33143bf10e6330e0f84" datatype="html">
         <source>Bakend - a server that allows you to run Zonemaster tests and save results using a JSON-RPC API and a database.</source>
+        <target state="translated">&quot;Backend&quot; - un servidor interno que permite ejecutar las pruebas de Zonemaster y guardar los resultados, usando una API JSON-RPC y una base de datos.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="f607354c1d0aba750b042d6f9c715efb699b5b7e" datatype="html">
         <source>GUI - a web interface to the Backend.</source>
+        <target state="translated">GUI - una interfaz web hacia el Backend.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="57c82df8ab9888592cfd3419caf75ec72c794db6" datatype="html">
         <source>When a domain name (such as &apos;zonemaster.net&apos;) is submitted to Zonemaster (using CLI or GUI), it will verify the domain name’s general health with a series of tests. The tests conducted by Zonemaster can be found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>the Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
+        <target state="translated">Cuando un nombre de dominio (tal como &quot;zonemaster.net&quot;) es enviado a Zonemaster (usando la CLI o GUI), este verificará el estado de salud general del nombre de dominio con una serie de pruebas. Las distintas pruebas realizadas por Zonemaster están documentadas en el documento de <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definición de Casos de Pruebas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="1072f67587614ba02bf775b31fcf47604c0a74d9" datatype="html">
         <source>Users who are knowledgable about the DNS protocol.</source>
+        <target state="translated">Usuarios que entienden bien el protocolo DNS.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="bcc9e8cca9979fe26d8cc69c1b7dda20d67fb6ec" datatype="html">
         <source>Secondly, all tests that Zonemaster runs are defined in Test Case specifications that can be found in the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
+        <target state="translated">En segundo lugar, todas las pruebas que ejecuta Zonemaster son definidas en Especificaciones de Casos de Prueba que están enlazadas desde el documento <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definición de Casos de Pruebas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="93e3b326e8c6a335517ce06fd8e4fb60b32022d6" datatype="html">
         <source>Thirdly, Zonemaster can be used to test undelegated domain names. See <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#what-is-an-undelegated-domain-test&quot;&gt;"/>Question 12<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
         <note priority="1" from="description">faq answer</note>
-        <target state="new">Thirdly, Zonemaster can be used to test undelegated domain names. See <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#what-is-an-undelegated-domain-test&quot;&gt;"/>Question 12<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
+        <target state="translated">En tercer lugar, Zonemaster puede ser utilizado para probar dominios no-delegados. Más información sobre dominios no-delegados en la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#what-is-an-undelegated-domain-test&quot;&gt;"/>Pregunta 12<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
       </trans-unit>
       <trans-unit id="d935513e236ca268ce40c309a7e3dc8ffdb4644b" datatype="html">
         <source>Fourthly, Zonemaster can be used to test DS records before their publication in the parent zone (which is required to enable DNSSEC for a signed zone). See <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>Question 13<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
         <note priority="1" from="description">faq answer</note>
-        <target state="new">Fourthly, Zonemaster can be used to test DS records before their publication in the parent zone (which is required to enable DNSSEC for a signed zone). See <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>Question 13<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
+        <target state="translated">En cuarto lugar, Zonemaster puede usarse para probar registros DS antes de ser publicados en la zona padre (lo que es necesario para habilitar DNSSEC en una zona firmada). Ver la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>Pregunta 13<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
       </trans-unit>
       <trans-unit id="d64e48938dc174ff3a27321a096a8aed44cb55cf" datatype="html">
         <source>The judgement of Zonemaster is primarily based on the DNS standards as defined in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;RFC Wikipedia link&quot; href=&quot;https://en.wikipedia.org/wiki/Request_for_Comments&quot;&gt;"/>RFCs<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. It also bases its judgement on DNS best practices, which can be more loosely defined. All Zonemaster tests are defined in <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Test Case Specifications<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> in which the references to the standard documents for that test case are found.</source>
+        <target state="needs-l10n">El criterio de Zonemaster se basa principalmente en los estándares DNS definidos en los <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;RFC Wikipedia link&quot; href=&quot;https://en.wikipedia.org/wiki/Request_for_Comments&quot;&gt;"/>RFCs<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. También basa su criterio en las mejores prácticas del DNS, que pueden ser definiciones un poco más vagas. Todas las pruebas de Zonemaster están definidas en el el documento de <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definición de Casos de Pruebas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés), donde se encuentran las referencias a los documentos de estándar relevantes para cada caso.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="b37b77d5a9ec277db643fecb7e0d9e6ced910cfd" datatype="html">
         <source>The GUI interface of Zonemaster does not show any queries sent, only the CLI interface can. If you want to see such queries, you will have to locally install a minimally working Zonemaster instance with both the Engine and CLI components (a Docker image is also available). Queries sent can be shown using the &apos;DEBUG&apos; level option. Fair warning, the output from the CLI can be quite heavy. For more information see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md&quot;&gt;"/>Using The CLI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target state="translated">La interfaz gráfica (GUI) de Zonemaster no muestra ninguna de las consultas que envía, solo la interfaz CLI lo puede hacer. Si quiere ver esas consultas, deberá instalar localmente una instancia con funcionamiento mínimo de los componentes Engine y CLI (hay una imagen Docker disponible). Las consultas enviadas pueden mostrarse usando la opción de nivel &apos;DEBUG&apos;. Le advertimos que la salida del CLI puede ser bastante compleja. Para más información ver <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md&quot;&gt;"/>Usando la CLI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="3e875c84ab956c8df30ae1965dc0cde70364441f" datatype="html">
         <source>Since <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://zonemaster.net/&quot;&gt;"/>Zonemaster.net<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is open to everyone it is possible for anyone to check your domain and its history of tests. However there is no way to tell who has run a specific test since nothing more than the test parameters and results are stored. Specifically, no cookies or information on the user&apos;s IP address is stored in the database. The user who initiated the test cannot be traced back from the information in the database.</source>
+        <target state="translated">Dado que <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://zonemaster.net/&quot;&gt;"/>Zonemaster.net<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> es abierto a todos, es posible que cualquiera pueda probar tu dominio y ver la historia de pruebas anteriores. Sin embargo, no hay forma de saber quién ejecutó una prueba en específico, ya que solo se almacena los parámetros de la prueba y sus resultados. En específico, no se almacenan ni las cookies ni la dirección IP del usuario. El usuario que inició la prueba no puede ser rastreado usando la información de la base de datos.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="35616e74e8222cbe39e0e9e1d4451538fe760238" datatype="html">
         <source>It depends on which test failed for your domain name. Each test are accompanied with one or several messages describing the issues found. You can also get further insight about each test from the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
+        <target state="translated">Depende cuáles de las pruebas fallaron en su dominio. Cada prueba está acompañada por uno o más mensajes que describen los problemas encontrados. También puede encontrar más detalles de cada prueba en el documento de <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definición de Casos de Pruebas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="67f7a9ad43bbcaca9531388e8a49fcc6edcaed74" datatype="html">

--- a/src/locale/messages.es.xlf
+++ b/src/locale/messages.es.xlf
@@ -443,9 +443,9 @@
         <target state="translated">¿Quién está detrás de Zonemaster?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="2c2546090ea5fa029ce31f5d5390dce114a5c9a8" datatype="html">
-        <source>Zonemaster is a joint project between <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registry of &apos;.fr&apos; TLD and several other TLDs, e.g. &apos;.re&apos;, &apos;.pm&apos;, &apos;.tf&apos;, &apos;.wf&apos;, &apos;.yt&apos; and &apos;.paris&apos;) and <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registry of &apos;.se&apos; and &apos;.nu&apos; TLDs).</source>
-        <target state="translated">Zonemaster es un proyecto conjunto entre <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registro para el TLD .fr y varios otros, por ejemplo .re, .pm, .tf, .wf, .yt y .paris) y <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registro de los TLDs .se y .nu).</target>
+      <trans-unit id="b77096ab862e1ae84890007b66996ffe87848828" datatype="html">
+        <source>Zonemaster is a joint project between <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, the registry of &apos;.fr&apos; TLD and several other TLDs like &apos;.re&apos;, &apos;.pm&apos;, &apos;.tf&apos;, &apos;.wf&apos;, &apos;.yt&apos; and &apos;.paris&apos;, and <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, the registry of &apos;.se&apos; and &apos;.nu&apos; TLDs.</source>
+        <target state="new">Zonemaster es un proyecto conjunto entre <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registro para el TLD .fr y varios otros, por ejemplo .re, .pm, .tf, .wf, .yt y .paris) y <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registro de los TLDs .se y .nu).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="e2bf4547393abb2e5e4c77cfaaeb79e8f85a541c" datatype="html">
@@ -458,9 +458,9 @@
         <target state="translated">La herramienta Zonemaster está orientada a dos categorías de usuarios:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="90e55bb71b57ffa3d778c6a9e676c505d4b897cb" datatype="html">
-        <source>Users who just want to know whether the domain name they own or use have any issues or not.</source>
-        <target state="translated">Usuarios que solo quieren saber si el nombre de dominio que poseen o usan tiene algún problema.</target>
+      <trans-unit id="07641f98e2977d5ceaea98ceac94a82f0787e6fc" datatype="html">
+        <source>users who want to know whether the domain name they own or use have any issues or not.</source>
+        <target state="new">Usuarios que solo quieren saber si el nombre de dominio que poseen o usan tiene algún problema.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="7f82cd00cb66740b1e8e6695ceb6987d951e38e5" datatype="html">
@@ -473,14 +473,14 @@
         <target state="translated">¿Qué hace distinto a Zonemaster de otros software de validación DNS?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="3942f9186d69777597c1fba63f78762033da2ee4" datatype="html">
-        <source>Firstly, Zonemaster saves all history from earlier tests based on the tested domain name, which means you can go back to a test you did some time ago and compare it to the test you ran just a moment ago.</source>
-        <target state="translated">Primero que todo, Zonemaster guarda toda la historia de pruebas anteriores basadas en el nombre del dominio probado, de tal forma que puedes ir hacia atrás a una prueba que hiciste hace un tiempo, y compararla con la prueba que acabas de hacer hace unos momentos.</target>
+      <trans-unit id="c625cfabcffbab7888c7bb7b57387ef5921eaf17" datatype="html">
+        <source>Zonemaster saves all history from earlier tests based on the tested domain name, which means you can go back to a test you did some time ago and compare it to the test you ran just a moment ago.</source>
+        <target state="new">Primero que todo, Zonemaster guarda toda la historia de pruebas anteriores basadas en el nombre del dominio probado, de tal forma que puedes ir hacia atrás a una prueba que hiciste hace un tiempo, y compararla con la prueba que acabas de hacer hace unos momentos.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="5bad6b87847399d805291b8a8d89a84ef6576c42" datatype="html">
-        <source>Lastly, this open source version of Zonemaster was built using modular code which basically means that you can integrate parts of it in your own systems, if you wish. For example, it is quite rare that you would want a complete program just to check for redelegations.</source>
-        <target state="translated">Por último, esta versión de código abierto de Zonemaster fue construida usando código modular, lo que básicamente significa que puedes integrar partes del software en tus propios sistemas, si así lo quisieras. Por ejemplo, es muy raro que quieras instalar un programa completo para sólo probar redelegaciones.</target>
+      <trans-unit id="865aac49d53d372537909b1df21a9d111d50c9f1" datatype="html">
+        <source>This open source version of Zonemaster was built using modular code which basically means that you can integrate parts of it in your own systems, if you wish. For example, it is quite rare that you would want a complete program just to check for redelegations.</source>
+        <target state="new">Por último, esta versión de código abierto de Zonemaster fue construida usando código modular, lo que básicamente significa que puedes integrar partes del software en tus propios sistemas, si así lo quisieras. Por ejemplo, es muy raro que quieras instalar un programa completo para sólo probar redelegaciones.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="f3a7aab6d6b07e6db0c1ba7e4b88f53430d5ce81" datatype="html">
@@ -493,14 +493,14 @@
         <target state="translated">A veces hay distintas interpretaciones de los estándares, u opiniones de lo que es una buena práctica, y el equipo de Zonemaster siempre está abierto a sugerencias. Si crees que hemos cometido un error de criterio, por favor no dudes en enviarnos un email a <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:zonemaster-users@lists.iis.se&quot;&gt;"/>zonemaster-users@lists.iis.se<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (lista de correo moderada) con un enlace al resultado de tu prueba y una explicación por qué crees que muestra algo que consideres incorrecto.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="076e3c1beadaa4e6ba7989124471ab3d14bbc523" datatype="html">
-        <source>What kind of queries does Zonemaster generate?</source>
-        <target state="translated">¿Qué tipo de consultas genera Zonemaster?</target>
+      <trans-unit id="43b794c269088e266109a7e6325a2735fa84dea5" datatype="html">
+        <source>What kind of DNS queries does Zonemaster generate?</source>
+        <target state="new">¿Qué tipo de consultas genera Zonemaster?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="56c265f73e958064c7bcfee6e566516e03066c1a" datatype="html">
-        <source>Zonemaster send multiple DNS queries to the name servers hosting the domain name being tested and also to the name servers hosting the parent zone of that domain name.</source>
-        <target state="translated">Zonemaster envía múltiples consultas DNS a los servidores de nombre que hospedan al nombre de dominio que se está probando, y también a los servidores de nombre que hospedan la zona padre del nombre de dominio.</target>
+      <trans-unit id="b8a8b9d2be7823698c2748be55f00c74bc24aebc" datatype="html">
+        <source>Zonemaster sends multiple DNS queries to the name servers hosting the domain name being tested and also to the name servers hosting the parent zone of that domain name.</source>
+        <target state="new">Zonemaster envía múltiples consultas DNS a los servidores de nombre que hospedan al nombre de dominio que se está probando, y también a los servidores de nombre que hospedan la zona padre del nombre de dominio.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="441b723a458aa167da55ee24002ef0a38ac81a96" datatype="html">
@@ -518,9 +518,9 @@
         <target state="translated">¿Por qué no puedo probar mi nombre de dominio?</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="67269fee7f44c79618ab1c709d8dd53949545984" datatype="html">
-        <source>There are several possibilities:</source>
-        <target state="translated">Puede haber varias posibilidades:</target>
+      <trans-unit id="0bdf75b30593d6ecbd74e34628d90e8530ec8e05" datatype="html">
+        <source>There are several possibilities.</source>
+        <target state="new">Puede haber varias posibilidades:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="5ade768ec4a2e175bdcc18687d04ef22efa461da" datatype="html">
@@ -533,14 +533,14 @@
         <target state="translated">Su nombre de dominio no es alcanzable desde la Internet pública.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="2c3a34d5c350d025523503260d7b7fd2be5bd297" datatype="html">
-        <source>Zonemaster can only test what is called a DNS zone (e.g. &apos;zonemaster.net&apos;) and not host names (e.g. &apos;www.zonemaster.net&apos;)</source>
-        <target state="translated">Zonemaster solo puede probar una zona DNS (por ej. &apos;zonemaster.net&apos;) y no nombres de host (por ej. &apos;www.zonemaster.net&apos;).</target>
+      <trans-unit id="af5d964bcd860fb4c49b4df68b7cbe3aa7d3b8a4" datatype="html">
+        <source>Zonemaster can only test what is called a DNS zone, for example &apos;zonemaster.net&apos;, and not host names, like &apos;www.zonemaster.net&apos;.</source>
+        <target state="new">Zonemaster solo puede probar una zona DNS (por ej. &apos;zonemaster.net&apos;) y no nombres de host (por ej. &apos;www.zonemaster.net&apos;).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="eb42d0a7485a530b74a81467195b779cdb447607" datatype="html">
-        <source>There is a 10 minutes protection between consecutive tests for a given domain name (with same test parameters). Running a test within that window will instead show the last available test for that domain name (and parameters).</source>
-        <target state="translated">Existe una protección de 10 minutos entre pruebas consecutivas por un nombre de dominio determinado (con los mismos parámetros de pruebas). Al ejecutar una prueba dentro de esa ventana de tiempo, se mostrará el último resultado que se se obtuvo para ese nombre de dominio (con los mismos parámetros).</target>
+      <trans-unit id="d31b5b7a11a5d9b2ef21b1b92f3b4a23550a5e24" datatype="html">
+        <source>There is a 10 minutes protection between consecutive tests for a given domain name, with same test parameters. Running a test within that window will instead show the last available test for that domain name, and parameters.</source>
+        <target state="new">Existe una protección de 10 minutos entre pruebas consecutivas por un nombre de dominio determinado (con los mismos parámetros de pruebas). Al ejecutar una prueba dentro de esa ventana de tiempo, se mostrará el último resultado que se se obtuvo para ese nombre de dominio (con los mismos parámetros).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="3fa205532eeda5bef22a1c0268e823b691682f2e" datatype="html">
@@ -558,19 +558,14 @@
         <target state="translated">¿Qué es una prueba de dominio no-delegado?</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="e9e0008a5b47b371cc2f592e2b07f7f436f69579" datatype="html">
-        <source>An undelegated domain test is a test performed on a domain name that may, or may not, be fully published in the DNS. This can be quite useful if one is going to migrate one&apos;s domain from one registrar to another, e.g., migrate zone &apos;example.com&apos; from the name server &apos;ns.example.com&apos; to the name server &apos;ns.example.org&apos;. In this scenario one could perform an undelegated domain test providing the zone (&apos;example.com&apos;) and the name server you are migrating to (&apos;ns.example.org&apos;) before you migrate your domain. When the results of the test doesn&apos;t show any errors or warnings one can be fairly certain that the domain&apos;s new location is working well. However there might still be other problems in the zone data itself that this test is unaware of.</source>
-        <target state="translated">Una prueba de dominio no-delegado es una prueba ejecutada sobre un nombre de dominio que puede o no estar completamente publicado en el DNS. Esto es muy útil cuando uno quiere mover un nombre de dominio desde un registrador a otro, por ejemplo al mover la zona example.com desde el servidor de nombres &quot;ns.example.com&quot; al servidor &quot;ns.example.org&quot;. En este escenario, uno podría ejecutar una prueba de dominio no-delegado indicando la zona (example.com) y el servidor de nombres futuro al cual va a mover el dominio (ns.example.org) antes de que muevas el dominio. Cuando obtenga los resultados de las pruebas en verde, uno puede estar suficientemente seguro que la nueva ubicación del dominio está funcionando correctamente. Sin embargo, puede haber otros problemas en los datos de la zona en sí misma, que esta prueba ignora.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
       <trans-unit id="714b9a1e26a0fb83903c47c5861168eb802f14c8" datatype="html">
         <source>Does Zonemaster support IPv6?</source>
         <target state="translated">¿Zonemaster soporta IPv6?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="e202abce3d27b876ce27b42e2c65c4109d902e00" datatype="html">
-        <source>Yes. By default Zonemaster will query name servers both over IPv4 and IPv6, unless explicitly configured otherwise. Such configuration is accessible through the &quot;Options&quot; button.</source>
-        <target state="translated">Sí. Por defecto Zonemaster consultará a los servidores de nombre usando IPv4 e IPv6, a menos que sea configurado explícitamente de otra forma. Esta configuración se encuentra en el botón &quot;Opciones&quot;.</target>
+      <trans-unit id="2350f8b4d24d63516eb8f8a6d71e67c72e323c15" datatype="html">
+        <source>Yes. By default Zonemaster will query name servers both over IPv4 and IPv6, unless explicitly configured otherwise. Such configuration is accessible through the &quot;Show options&quot; button.</source>
+        <target state="new">Sí. Por defecto Zonemaster consultará a los servidores de nombre usando IPv4 e IPv6, a menos que sea configurado explícitamente de otra forma. Esta configuración se encuentra en el botón &quot;Opciones&quot;.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="0a5f5612b4d2dfb3a9bf032f9815e6228d0721a6" datatype="html">
@@ -588,9 +583,9 @@
         <target state="translated">¿Puedo probar los registros DS antes de ser publicados?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="2e3dcb30f608294a8ca15718a32604ced7555f7a" datatype="html">
-        <source>Yes. Use the &quot;Options&quot; button and there add the Delegation Signer (DS) records to be tested. Zonemaster will then use those in the same way as if they were already added in the parent zone.</source>
-        <target state="translated">Sí. Puede utilizar el botón &quot;Opciones&quot; y agregar ahí los registros &quot;Delegation Signer&quot; (DS) que quiera probar. Zonemaster los usará de la misma forma que si hubieran sido obtenidos desde la zona padre.</target>
+      <trans-unit id="82472afd59b9bd004901d8692b87752d48f62792" datatype="html">
+        <source>Yes. Use the &quot;Show options&quot; button and there add the Delegation Signer (DS) records to be tested. Zonemaster will then use those in the same way as if they were already added in the parent zone.</source>
+        <target state="new">Sí. Puede utilizar el botón &quot;Opciones&quot; y agregar ahí los registros &quot;Delegation Signer&quot; (DS) que quiera probar. Zonemaster los usará de la misma forma que si hubieran sido obtenidos desde la zona padre.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="794667cd8ae08bd15b1d9943e03f8b2886ee6f65" datatype="html">
@@ -608,14 +603,14 @@
         <target state="translated">Ejemplos:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="93c29dbaff15d2569875f4e67925d39859eeb465" datatype="html">
-        <source>For IPv4 prefix &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa</source>
-        <target state="translated">Para el prefijo IPv4 &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa</target>
+      <trans-unit id="f391e31fd1b3fb7063c9048af39cb6a95aa0a193" datatype="html">
+        <source>for IPv4 prefix &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa;</source>
+        <target state="new">Para el prefijo IPv4 &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="699eaa999ec82b70f68bf14932cc97ad893a0e0b" datatype="html">
-        <source>For IPv6 prefix &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa</source>
-        <target state="translated">Para el prefijo IPv6 &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa</target>
+      <trans-unit id="c11b2629ee75f3f6ab277dd82b742a4b28c86a39" datatype="html">
+        <source>for IPv6 prefix &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa.</source>
+        <target state="new">Para el prefijo IPv6 &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="56a21bdcd76a6ac5dd60c17f5170b999b63e0ac0" datatype="html">
@@ -703,9 +698,9 @@
         <target state="new">Expand all modules</target>
         <note priority="1" from="description">result filter messages</note>
       </trans-unit>
-      <trans-unit id="99a0620d495f0d1ab864174f77a560140c5e214a" datatype="html">
-        <source>The descriptions of message levels such as <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>notice<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>warning<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> and <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> are found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Severity Level Definitions<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <target state="translated">Las descripciones de los niveles de mensaje, como <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>información<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>advertencia<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> y <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> se encuentran en <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Definiciones de Nivel de Gravedad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
+      <trans-unit id="1653de50d322462bc8c27d7e1735fee3836e8475" datatype="html">
+        <source>The descriptions of message levels such as <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>NOTICE<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>WARNING<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> and <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>ERROR<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> are found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Severity Level Definitions<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target state="new">Las descripciones de los niveles de mensaje, como <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>información<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>advertencia<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> y <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> se encuentran en <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Definiciones de Nivel de Gravedad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="6d41e759de3c0117413b5a6e5b5cd3f44ecb4676" datatype="html">
@@ -715,81 +710,6 @@
       <trans-unit id="851258c348e2a703d4a845053c198287c11d5601" datatype="html">
         <source>Created on</source>
         <note priority="1" from="description">result test metadata</note>
-      </trans-unit>
-      <trans-unit id="c51835a3345882fb12374bddfd2e4b73e4f69db8" datatype="html">
-        <source>Zonemaster is a program designed to help people check, measure and hopefully also understand how the DNS (Domain Name System) works.</source>
-        <target state="translated">Zonemaster es un programa diseñado para ayudar a la gente a revisar, medir y ojalá también entender cómo funciona el DNS (Sistema de Nombres de Dominio).</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="11aba2484b1af47b7dcd308237d231d0dd666d65" datatype="html">
-        <source>It consists of several components:</source>
-        <target state="translated">Consiste de varios componentes:</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="cd1f6944c474bd4875b37226edbe8ed0b802ef1a" datatype="html">
-        <source>Engine - a test framework that supports all functionality to perform DNS tests.</source>
-        <target state="translated">&quot;Engine&quot; (Motor) - una arquitectura de pruebas que soporta toda la funcionalidad para realizar pruebas DNS.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="8f95b69eb8b7f2620f2bf39028a754efbb02e17c" datatype="html">
-        <source>CLI - a command-line interface to the Engine.</source>
-        <target state="translated">&quot;CLI&quot; - una interfaz de línea de comandos hacia el Engine.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="fdfa7928b51beb9b7143d33143bf10e6330e0f84" datatype="html">
-        <source>Bakend - a server that allows you to run Zonemaster tests and save results using a JSON-RPC API and a database.</source>
-        <target state="translated">&quot;Backend&quot; - un servidor interno que permite ejecutar las pruebas de Zonemaster y guardar los resultados, usando una API JSON-RPC y una base de datos.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="f607354c1d0aba750b042d6f9c715efb699b5b7e" datatype="html">
-        <source>GUI - a web interface to the Backend.</source>
-        <target state="translated">GUI - una interfaz web hacia el Backend.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="57c82df8ab9888592cfd3419caf75ec72c794db6" datatype="html">
-        <source>When a domain name (such as &apos;zonemaster.net&apos;) is submitted to Zonemaster (using CLI or GUI), it will verify the domain name’s general health with a series of tests. The tests conducted by Zonemaster can be found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>the Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
-        <target state="translated">Cuando un nombre de dominio (tal como &quot;zonemaster.net&quot;) es enviado a Zonemaster (usando la CLI o GUI), este verificará el estado de salud general del nombre de dominio con una serie de pruebas. Las distintas pruebas realizadas por Zonemaster están documentadas en el documento de <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definición de Casos de Pruebas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="1072f67587614ba02bf775b31fcf47604c0a74d9" datatype="html">
-        <source>Users who are knowledgable about the DNS protocol.</source>
-        <target state="translated">Usuarios que entienden bien el protocolo DNS.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="bcc9e8cca9979fe26d8cc69c1b7dda20d67fb6ec" datatype="html">
-        <source>Secondly, all tests that Zonemaster runs are defined in Test Case specifications that can be found in the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
-        <target state="translated">En segundo lugar, todas las pruebas que ejecuta Zonemaster son definidas en Especificaciones de Casos de Prueba que están enlazadas desde el documento <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definición de Casos de Pruebas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="93e3b326e8c6a335517ce06fd8e4fb60b32022d6" datatype="html">
-        <source>Thirdly, Zonemaster can be used to test undelegated domain names. See <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#what-is-an-undelegated-domain-test&quot;&gt;"/>Question 12<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <note priority="1" from="description">faq answer</note>
-        <target state="translated">En tercer lugar, Zonemaster puede ser utilizado para probar dominios no-delegados. Más información sobre dominios no-delegados en la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#what-is-an-undelegated-domain-test&quot;&gt;"/>Pregunta 12<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
-      </trans-unit>
-      <trans-unit id="d935513e236ca268ce40c309a7e3dc8ffdb4644b" datatype="html">
-        <source>Fourthly, Zonemaster can be used to test DS records before their publication in the parent zone (which is required to enable DNSSEC for a signed zone). See <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>Question 13<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <note priority="1" from="description">faq answer</note>
-        <target state="translated">En cuarto lugar, Zonemaster puede usarse para probar registros DS antes de ser publicados en la zona padre (lo que es necesario para habilitar DNSSEC en una zona firmada). Ver la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>Pregunta 13<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
-      </trans-unit>
-      <trans-unit id="d64e48938dc174ff3a27321a096a8aed44cb55cf" datatype="html">
-        <source>The judgement of Zonemaster is primarily based on the DNS standards as defined in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;RFC Wikipedia link&quot; href=&quot;https://en.wikipedia.org/wiki/Request_for_Comments&quot;&gt;"/>RFCs<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. It also bases its judgement on DNS best practices, which can be more loosely defined. All Zonemaster tests are defined in <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Test Case Specifications<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> in which the references to the standard documents for that test case are found.</source>
-        <target state="needs-l10n">El criterio de Zonemaster se basa principalmente en los estándares DNS definidos en los <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;RFC Wikipedia link&quot; href=&quot;https://en.wikipedia.org/wiki/Request_for_Comments&quot;&gt;"/>RFCs<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. También basa su criterio en las mejores prácticas del DNS, que pueden ser definiciones un poco más vagas. Todas las pruebas de Zonemaster están definidas en el el documento de <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definición de Casos de Pruebas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés), donde se encuentran las referencias a los documentos de estándar relevantes para cada caso.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="b37b77d5a9ec277db643fecb7e0d9e6ced910cfd" datatype="html">
-        <source>The GUI interface of Zonemaster does not show any queries sent, only the CLI interface can. If you want to see such queries, you will have to locally install a minimally working Zonemaster instance with both the Engine and CLI components (a Docker image is also available). Queries sent can be shown using the &apos;DEBUG&apos; level option. Fair warning, the output from the CLI can be quite heavy. For more information see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md&quot;&gt;"/>Using The CLI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <target state="translated">La interfaz gráfica (GUI) de Zonemaster no muestra ninguna de las consultas que envía, solo la interfaz CLI lo puede hacer. Si quiere ver esas consultas, deberá instalar localmente una instancia con funcionamiento mínimo de los componentes Engine y CLI (hay una imagen Docker disponible). Las consultas enviadas pueden mostrarse usando la opción de nivel &apos;DEBUG&apos;. Le advertimos que la salida del CLI puede ser bastante compleja. Para más información ver <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md&quot;&gt;"/>Usando la CLI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="3e875c84ab956c8df30ae1965dc0cde70364441f" datatype="html">
-        <source>Since <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://zonemaster.net/&quot;&gt;"/>Zonemaster.net<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is open to everyone it is possible for anyone to check your domain and its history of tests. However there is no way to tell who has run a specific test since nothing more than the test parameters and results are stored. Specifically, no cookies or information on the user&apos;s IP address is stored in the database. The user who initiated the test cannot be traced back from the information in the database.</source>
-        <target state="translated">Dado que <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://zonemaster.net/&quot;&gt;"/>Zonemaster.net<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> es abierto a todos, es posible que cualquiera pueda probar tu dominio y ver la historia de pruebas anteriores. Sin embargo, no hay forma de saber quién ejecutó una prueba en específico, ya que solo se almacena los parámetros de la prueba y sus resultados. En específico, no se almacenan ni las cookies ni la dirección IP del usuario. El usuario que inició la prueba no puede ser rastreado usando la información de la base de datos.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="35616e74e8222cbe39e0e9e1d4451538fe760238" datatype="html">
-        <source>It depends on which test failed for your domain name. Each test are accompanied with one or several messages describing the issues found. You can also get further insight about each test from the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
-        <target state="translated">Depende cuáles de las pruebas fallaron en su dominio. Cada prueba está acompañada por uno o más mensajes que describen los problemas encontrados. También puede encontrar más detalles de cada prueba en el documento de <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definición de Casos de Pruebas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (en inglés).</target>
-        <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="67f7a9ad43bbcaca9531388e8a49fcc6edcaed74" datatype="html">
         <source>Show options</source>
@@ -822,6 +742,98 @@
       <trans-unit id="c8519a4a202001557a05f640963735dbf5f07b33" datatype="html">
         <source>Digest of DS record #<x id="INTERPOLATION" equiv-text="{{i + 1}}"/></source>
         <note priority="1" from="description">form label</note>
+      </trans-unit>
+      <trans-unit id="2704926571b86d6e027c0ee69e9cf92df0cf9096" datatype="html">
+        <source>Zonemaster is a software package that validates the quality of a DNS delegation.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="1b3fa683ecfec35c6e3ac7fbfd50b7c689199a54" datatype="html">
+        <source>The ambition of the Zonemaster project is to develop and maintain an open source DNS validation tool, offering improved performance over existing tools and providing extensive documentation which could be re-used by similar projects in the future.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="51e39416d99fddd056c99788c01f9bc7b66f2037" datatype="html">
+        <source>Zonemaster consists of several modules or components:</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="e4f6c60a296bfd008d340c5dfff98bba363d3e82" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster-engine&quot;&gt;"/>Engine<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, a test framework that supports all functionality to perform DNS tests;</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="d26c43d02a42969864698f92af212eaf479d68e6" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster-cli&quot;&gt;"/>CLI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, a command-line interface to the Engine;</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="b9c39a4ac7f467c9db860a66a5ce8b1db9a1c820" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster-backend&quot;&gt;"/>Bakend<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, a server that allows you to run Zonemaster tests and save results using a JSON-RPC API and a database;</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="333892b5f3094578ceccffb29e7498c1c5fdf3b5" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster-engine&quot;&gt;"/>GUI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, a web interface to the Backend.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="7aec1bc450ef7a1d3fbec65dc277ea4564f25c9e" datatype="html">
+        <source>The components will help different types of users to check domain servers for configuration errors and generate a report that will assist in fixing the errors.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="34d009ab9be7fd622ac9e49201cf5c6bdf747234" datatype="html">
+        <source>DNS administrator, experts and beginners alike, who want to check their DNS configuration;</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="f54e9dd707ef19b613b8e24eb27ff8c665a39e5d" datatype="html">
+        <source>All tests that Zonemaster runs are defined in the Test Case Specification documents that can be found in the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#zonemaster-test-case-specifications&quot;&gt;"/>Test Case Specification documents<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="92585a3d52e50d27907f2141840ef9d5800403f3" datatype="html">
+        <source>Zonemaster can be used to test <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;./faq#what-is-an-undelegated-domain-test&quot;&gt;"/>undelegated domain names<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="715189970a83f785ee5d931b3a2b33c6b60bc33f" datatype="html">
+        <source>Zonemaster can be used to test <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;./faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>DS records before their publication<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> in the parent zone.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="e9d270f1198af607f593dfce5fa7a2e88a622f28" datatype="html">
+        <source>The judgement of Zonemaster is primarily based on the DNS standards as defined in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;RFC Wikipedia link&quot; href=&quot;https://en.wikipedia.org/wiki/Request_for_Comments&quot;&gt;"/>RFCs<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. It also bases its judgement on DNS best practices, which can be more loosely defined.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="d42eedec9f66855cb398b2adc1f100ac8367a9cc" datatype="html">
+        <source>All Zonemaster tests are defined in the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#zonemaster-test-case-specifications&quot;&gt;"/>Test Case Specification documents<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> in which the references to the standard documents for each test case are found.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="b5d49764acaeaa151a5ac5febf896ee2b3057de0" datatype="html">
+        <source>The web interface of Zonemaster does not show the queries that were sent, only the CLI interface can. If you want to see such queries, you will have to locally install a minimally working Zonemaster instance with both the Engine and CLI components. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/installation/zonemaster-cli.md&quot;&gt;"/>CLI installation document<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for more information, or if you prefer a <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md#Invoking-the-command-line-tool-using-Docker&quot;&gt;"/>Docker image<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is also available.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="af1bfafbbbdcd9b1592d3d49c002a03ef057ee8f" datatype="html">
+        <source>Queries sent can be shown using the &apos;DEBUG&apos; level option. Fair warning, the output from the CLI can be quite heavy. For more information see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md&quot;&gt;"/>CLI usage documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="9f4317f4bde59f85c3e772bc3b42dba428e95ec7" datatype="html">
+        <source>Nothing besides the test domain, other test parameters and the result is stored in the database. Specifically we do not store any information that could link a test to the user who initiated it.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="6be3dc81fccabd1e5fa54d429e0e4badaf23db6a" datatype="html">
+        <source>However, since <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://zonemaster.net&quot;&gt;"/>zonemaster.net<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, like other public instances, is open to everyone, it is possible for anyone to test your domain and view its history of tests.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="246dc6711fe797f1957f4437cca0f6bc11cbee7f" datatype="html">
+        <source>It depends on which test failed for your domain name. Each test is accompanied with one or several messages describing the issues found.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="78746b70d4f4c7a88a5f6782efe53a3bc7cb4760" datatype="html">
+        <source>You can also get further insight about each test from the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#zonemaster-test-case-specifications&quot;&gt;"/>Test Case Specification documents<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="3c349e204fd8fb384a917155fe745b99b649405f" datatype="html">
+        <source>An undelegated domain test is a test performed on a domain name that may, or may not, be fully published in the DNS.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="35389c3f661c8fdd9a78d46ea60aa8ed521432fa" datatype="html">
+        <source>This can be quite useful if one is going to migrate one&apos;s domain from one registrar to another, for example, migrate zone &apos;example.com&apos; from the name server &apos;ns.example.com&apos; to the name server &apos;ns.example.org&apos;. In this scenario one could perform an undelegated domain test providing the zone (&apos;example.com&apos;) and the name server you are migrating to (&apos;ns.example.org&apos;) before you migrate your domain.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="9ba22e50f767264efe18722dc728c9ee402181dc" datatype="html">
+        <source>When the results of the test doesn&apos;t show any errors or warnings one can be fairly certain that the domain&apos;s new location is working well. However there might still be other problems in the zone data itself that this test is unaware of.</source>
+        <note priority="1" from="description">faq answer</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Purpose

Try to fix the missing translations of the FAQ.

## Context

The translations system of the FAQ has changed. This import old translations into the new system.

## Changes

Spanish translations.

## How to test this PR

A quick check of the translated string would be welcome to verify that I haven't done any mistake while copy/pasting.