### PR TITLE
Improve run test form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zonemaster-gui",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zonemaster-gui",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@angular/animations": "^13.3.11",

--- a/src/app/components/form/form.component.css
+++ b/src/app/components/form/form.component.css
@@ -181,22 +181,25 @@ hr {
   margin: 0;
 }
 
-.domain button#advanced-toggle {
-  background: none;
-  border: none;
-  padding: 0;
+.domain summary#advanced-toggle {
   font-weight: bold;
+  list-style-type: none;
 }
 
-.domain button#advanced-toggle i {
-  width: 1em;
-  margin-right: .25em;
-  transform: rotate(0);
-  transition: 0.1s transform;
+.domain summary#advanced-toggle i {
+  margin-right: .5em;
 }
 
-.domain button#advanced-toggle[aria-expanded="true"] i {
-  transform: rotate(90deg);
+.domain details#advanced-options summary#advanced-toggle .opened-label {
+  display: none;
+}
+
+.domain details#advanced-options[open] summary#advanced-toggle .opened-label {
+  display: initial;
+}
+
+.domain details#advanced-options[open] summary#advanced-toggle .closed-label {
+  display: none;
 }
 
 /* Domain input */
@@ -224,10 +227,6 @@ hr {
   right: 0.5rem;
 }
 
-.domain .reset-form button:not(:disabled):hover i {
-  opacity: 1;
-}
-
 .domain .reset-form button {
   color: inherit;
   padding: 0;
@@ -237,6 +236,11 @@ hr {
   width: 2em;
   border: .2em solid white;
   background-color: #939393;
+}
+
+.domain .reset-form button:not(:disabled):hover,
+.domain .reset-form button:not(:disabled):focus {
+  background-color: black;
 }
 
 .domain .reset-form button i {

--- a/src/app/components/form/form.component.css
+++ b/src/app/components/form/form.component.css
@@ -229,14 +229,21 @@ hr {
 }
 
 .domain .reset-form button {
-  border: none;
   color: inherit;
   padding: 0;
+  border-radius: 1em;
+  line-height: 1;
+  height: 2em;
+  width: 2em;
+  border: .2em solid white;
+  background-color: #939393;
 }
 
 .domain .reset-form button i {
-  opacity: .5;
-  transition: opacity 0.1s;
+  color: white;
+  width: 1em;
+  height: 1em;
+  font-size: 1.3em;
 }
 
 .domain .progress-value {

--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -2,7 +2,7 @@
   <div class="domain-form-container">
     <label i18n="form label" for="input-domain-form">Domain name</label>
     <div class="domain-input-container">
-      <input type="text"
+      <input #domainInput type="text"
           class="form-control form-control-lg"
           [class.is-invalid]="domain.invalid && (domain.dirty || domain.touched)"
           [attr.aria-invalid]="domain.invalid && (domain.dirty || domain.touched)"
@@ -26,7 +26,7 @@
           i18n-title="form button"
           title="Clear domain input"
           class="btn grey">
-            <i class="fa fa-2x fa-times-circle" aria-hidden="true"></i>
+            <i class="fa fa-times" aria-hidden="true"></i>
         </button>
       </div>
 

--- a/src/app/components/form/form.component.html
+++ b/src/app/components/form/form.component.html
@@ -44,21 +44,15 @@
   </div>
   <div class="row advanced">
     <div class="col">
-      <button
-        type="button"
-        id="advanced-toggle"
-        (click)="toggleOptions()"
-        [class.enabled]="isAdvancedOptionEnabled"
-        aria-controls="advanced-options"
-        [attr.aria-expanded]="isAdvancedOptionEnabled"
-      >
-        <i class="fa fa-caret-right caret" aria-hidden="true"></i>
-        <ng-container i18n="form options" *ngIf="!isAdvancedOptionEnabled">Show options</ng-container>
-        <ng-container i18n="form options" *ngIf="isAdvancedOptionEnabled">Hide options</ng-container>
-      </button>
     </div>
 
-    <div *ngIf="isAdvancedOptionEnabled" id="advanced-options">
+    <details id="advanced-options">
+      <summary id="advanced-toggle">
+        <i class="fa fa-caret-right control" aria-hidden="true"></i>
+        <span i18n="form options" class="closed-label">Show options</span>
+        <span i18n="form options" class="opened-label">Hide options</span>
+      </summary>
+
       <aside class="row">
         <div class="info-notice alert alert-light">
           <i class="fa fa-2x fa-info-circle me-3" aria-hidden="true"></i>
@@ -69,11 +63,11 @@
         </div>
       </aside>
 
-      <fieldset>
+      <fieldset #nameserversForm>
         <legend i18n="form section">Nameservers</legend>
 
         <div class="form-section nameservers" formArrayName="nameservers">
-          <fieldset *ngFor="let ns of form.controls.nameservers.controls; let i=index" [formGroupName]="i">
+          <fieldset *ngFor="let ns of nameserversArray.controls; let i=index" [formGroupName]="i">
             <legend i18n="form section">Nameserver #{{ i + 1}}</legend>
             <div class="form-input-group">
               <label for="ns-{{i}}-name-input" i18n="form label">Name</label>
@@ -118,6 +112,7 @@
 
             <div class="delete-button-container">
               <button
+                type="button"
                 (click)="deleteRow('nameservers', i)"
                 class="btn delete"
                 i18n-title="form button"
@@ -137,10 +132,10 @@
 
       <hr>
 
-      <fieldset>
+      <fieldset #dsInfoForm>
         <legend i18n="form section">DS records</legend>
         <div class="form-section ds-records" formArrayName="ds_info">
-          <fieldset *ngFor="let ds_info of form.controls.ds_info.controls; let i=index" [formGroupName]="i">
+          <fieldset *ngFor="let ds_info of dsInfoArray.controls; let i=index" [formGroupName]="i">
             <legend i18n="form section">DS record #{{ i + 1}}</legend>
             <div class="form-input-group">
               <label for="ds-{{i}}-keytag-input" i18n="form label">Keytag</label>
@@ -247,6 +242,7 @@
 
             <div class="delete-button-container">
               <button
+                type="button"
                 (click)="deleteRow('ds_info',i)"
                 class="btn delete"
                 i18n-title="form button"
@@ -335,7 +331,7 @@
         </div>
       </div>
 
-    </div>
+    </details>
   </div>
   <div class="row launch-test">
     <div class="col text-center">

--- a/src/app/components/form/form.component.ts
+++ b/src/app/components/form/form.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, OnInit, Input, Output, SimpleChanges, OnChanges, SimpleChange, OnDestroy} from '@angular/core';
+import {Component, EventEmitter, OnInit, Input, Output, OnChanges, SimpleChange, OnDestroy, ViewChild, ElementRef} from '@angular/core';
 import {ViewEncapsulation} from '@angular/core';
 import {
   FormGroup,
@@ -20,6 +20,8 @@ import { AlertService } from '../../services/alert.service';
   encapsulation: ViewEncapsulation.None
 })
 export class FormComponent implements OnInit, OnChanges, OnDestroy {
+  @ViewChild('domainInput') domainInput!: ElementRef<HTMLInputElement>;
+
   @Input() isAdvancedOptionEnabled = false;
   @Input() formProgression;
   @Input() toggleFinished;
@@ -215,6 +217,8 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
 
   public resetForm() {
     this.form.controls.domain.reset('');
+    this.domainInput.nativeElement.focus();
+
   }
 
   public resetFullForm() {

--- a/src/app/components/result/result.component.html
+++ b/src/app/components/result/result.component.html
@@ -111,7 +111,7 @@
       </div>
     </fieldset>
 
-    <details id="severity-level-help">
+    <details id="severity-level-help" class="details-info">
       <summary>
         <i class="fa fa-chevron-right control" aria-hidden="true"></i>
         <i class="fa fa-info-circle me-1" aria-hidden="true"></i>

--- a/src/app/components/run-test/run-test.component.html
+++ b/src/app/components/run-test/run-test.component.html
@@ -1,6 +1,6 @@
 <section class="run-test">
     <ng-content></ng-content>
-    <app-form [isAdvancedOptionEnabled]="isAdvancedOptionEnabled"
+    <app-form
             [formProgression]="runTestProgression"
             [showProgressBar]="showProgressBar"
             [parentDataNS]="parentDataNS"
@@ -10,7 +10,5 @@
             [formError]="requestError"
             (onRunTest)="runTest($event)"
             (onFetchDataFromParent)="fetchFromParent($event)"
-            (onOpenOptions)="openOptions($event)"
-
     ></app-form>
 </section>

--- a/src/app/components/run-test/run-test.component.ts
+++ b/src/app/components/run-test/run-test.component.ts
@@ -15,7 +15,6 @@ import { FormComponent } from '../form/form.component';
 })
 export class RunTestComponent implements OnInit {
   private intervalTime: number;
-  public isAdvancedOptionEnabled = false;
   public runTestProgression = 0;
   public showResult = false;
   public showProgressBar = false;
@@ -58,10 +57,6 @@ export class RunTestComponent implements OnInit {
   });
   }
 
-  public openOptions(value) {
-    this.isAdvancedOptionEnabled = value;
-  }
-
   public runTest(data: object) {
     let testId: string;
 
@@ -82,7 +77,6 @@ export class RunTestComponent implements OnInit {
             clearInterval(handle);
             this.alertService.success($localize `Test completed!`, true);
             self.testId = testId;
-            self.isAdvancedOptionEnabled = false;
             self.showResult = true;
             self.showProgressBar = false;
             self.runTestProgression = 5;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -99,12 +99,12 @@ footer .tooltip {
 
 
 .faq-question,
-details {
+details.details-info {
   margin-bottom: 0.5rem;
 }
 
 .faq-question header,
-details summary {
+details.details-info summary {
   transition: .3s background;
   list-style: none;
   margin: 0;
@@ -117,7 +117,7 @@ details summary {
 }
 
 .faq-question header *,
-details summary * {
+details.details-info summary * {
   margin: 0;
 }
 
@@ -128,9 +128,9 @@ details summary * {
 .faq-question.open header,
 .faq-question header:hover,
 .faq-question header:focus-within,
-details[open] summary,
-details summary:hover,
-details summary:focus {
+details.details-info[open] summary,
+details.details-info summary:hover,
+details.details-info summary:focus {
   color: var(--primary-color-dark);
   background-color: var(--primary-color-lighter-hover);
 }
@@ -143,14 +143,14 @@ details summary .control {
 }
 
 .faq-question.open header,
-details[open] summary {
+details.details-info[open] summary {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
 
 .faq-question.open header ~ *,
-details[open] summary ~ * {
+details.details-info[open] summary ~ * {
   padding: .5em .75em;
   background-color: var(--primary-color-lighter);
   border: 1px solid var(--primary-color-light);


### PR DESCRIPTION
## Purpose

Reposition the focus on various action and fix NS and DS new row handling.

## Context

Addresses #446 

## Changes

* Move the focus back to the domain input when the "clear domain input" button is pressed
* Move the focus to the next "delete" button for NS and DS form rows or the previous one if the last one has been pressed
* Replace disclosure logic with a HTML native `detail` element (equivalent behaviour)
* Improve visual appearance of the "clear domain input" button when focused
* Fix: Ensure always one empty row is displayed
  How to reproduce bug:
  * Enter "1" in the first nameserver name input
  * Delete second row by pressing the delete row button
  * There is only one row left, and no way to add more row
* Fix: Changing the last empty row always add a new row
  How to reproduce the bug:
  * Enter "1" in the first nameserver name input
  * Enter "2" in the second nameserver name input
  * Clear input of namerserver name input "2"
  * Delete last (third) row by pressing the delete row button
  * Enter "2" in the second nameserver name input again
  * No new row appears


## How to test this PR
Move the focus back to the domain input
* Enter "domain" in the domain input
* Tab to the "Clear domain input" button
* Press Enter
* Check that the domain input is now empty and that the focus is back to the domain input

Move the focus to the delete button
* Enter "1" in the first nameserver name input
* Enter "2" in the second nameserver name input
* Tab to the second delete button
* Press Enter
* Check that the focus is still on the second delete button but there are only two row now
* Press Enter
* Check that nothing has changed (the last row is not deleted to ensure that an empty row is alway present)
* Tab back to the first delete button
* Press Enter
* Check that the focus is still on first delete button, there is now only one row and it is empty
* Repeat for the DS form section