### PR TITLE
Update Norwegian translation (FAQ mostly)

### DIFF
--- a/src/locale/messages.nb.xlf
+++ b/src/locale/messages.nb.xlf
@@ -440,9 +440,9 @@
         <target state="translated">Hvem har utviklet Zonemaster?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="2c2546090ea5fa029ce31f5d5390dce114a5c9a8" datatype="html">
-        <source>Zonemaster is a joint project between <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registry of &apos;.fr&apos; TLD and several other TLDs, e.g. &apos;.re&apos;, &apos;.pm&apos;, &apos;.tf&apos;, &apos;.wf&apos;, &apos;.yt&apos; and &apos;.paris&apos;) and <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (registry of &apos;.se&apos; and &apos;.nu&apos; TLDs).</source>
-        <target state="translated">Verktøyet er utviklet i et samarbeid mellom registreringstjenestene <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (.fr TLD og flere andre TLDs, f.eks. .re, .pm, .tf, .wf, .yt og .paris) og <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>Internetstiftelsen<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (.se og .nu TLDs).</target>
+      <trans-unit id="b77096ab862e1ae84890007b66996ffe87848828" datatype="html">
+        <source>Zonemaster is a joint project between <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, the registry of &apos;.fr&apos; TLD and several other TLDs like &apos;.re&apos;, &apos;.pm&apos;, &apos;.tf&apos;, &apos;.wf&apos;, &apos;.yt&apos; and &apos;.paris&apos;, and <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>The Swedish Internet Foundation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, the registry of &apos;.se&apos; and &apos;.nu&apos; TLDs.</source>
+        <target state="new">Verktøyet er utviklet i et samarbeid mellom registreringstjenestene <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;Afnic link&quot; href=&quot;https://www.afnic.fr/en/&quot;&gt;"/>AFNIC<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (.fr TLD og flere andre TLDs, f.eks. .re, .pm, .tf, .wf, .yt og .paris) og <x id="START_LINK_1" equiv-text="&lt;a i18n-href=&quot;IIS link&quot; href=&quot;https://internetstiftelsen.se/en/&quot;&gt;"/>Internetstiftelsen<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (.se og .nu TLDs).</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="e2bf4547393abb2e5e4c77cfaaeb79e8f85a541c" datatype="html">
@@ -455,9 +455,9 @@
         <target state="new">The Zonemaster tool could help different kind of users:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="90e55bb71b57ffa3d778c6a9e676c505d4b897cb" datatype="html">
-        <source>Users who just want to know whether the domain name they own or use have any issues or not.</source>
-        <target state="new">Users who just want to know whether the domain name they own or use have any issues or not.</target>
+      <trans-unit id="07641f98e2977d5ceaea98ceac94a82f0787e6fc" datatype="html">
+        <source>users who want to know whether the domain name they own or use have any issues or not.</source>
+        <target state="new">users who want to know whether the domain name they own or use have any issues or not.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="7f82cd00cb66740b1e8e6695ceb6987d951e38e5" datatype="html">
@@ -470,14 +470,14 @@
         <target state="translated">Hva er det for forskjell på Zonemaster og andre DNS-testverktøy?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="3942f9186d69777597c1fba63f78762033da2ee4" datatype="html">
-        <source>Firstly, Zonemaster saves all history from earlier tests based on the tested domain name, which means you can go back to a test you did some time ago and compare it to the test you ran just a moment ago.</source>
-        <target state="translated">For det første lagrer Zonemaster all historikk fra tidligere tester basert på det testede domenet. Det betyr at du kan gå tilbake til en test du gjorde for en uke siden og sammenligne den med testen du kjørte for et øyeblikk siden.</target>
+      <trans-unit id="c625cfabcffbab7888c7bb7b57387ef5921eaf17" datatype="html">
+        <source>Zonemaster saves all history from earlier tests based on the tested domain name, which means you can go back to a test you did some time ago and compare it to the test you ran just a moment ago.</source>
+        <target state="new">For det første lagrer Zonemaster all historikk fra tidligere tester basert på det testede domenet. Det betyr at du kan gå tilbake til en test du gjorde for en uke siden og sammenligne den med testen du kjørte for et øyeblikk siden.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="5bad6b87847399d805291b8a8d89a84ef6576c42" datatype="html">
-        <source>Lastly, this open source version of Zonemaster was built using modular code which basically means that you can integrate parts of it in your own systems, if you wish. For example, it is quite rare that you would want a complete program just to check for redelegations.</source>
-        <target state="translated">Til slutt ble denne open source-versjonen av Zonemaster bygget ved hjelp av modulkode som i utgangspunktet betyr at du kan bruke deler av den i systemene dine hvis du ønsker det. Det er ganske sjelden at du har et komplett program bare for å sjekke for eksempel omlegeringer.</target>
+      <trans-unit id="865aac49d53d372537909b1df21a9d111d50c9f1" datatype="html">
+        <source>This open source version of Zonemaster was built using modular code which basically means that you can integrate parts of it in your own systems, if you wish. For example, it is quite rare that you would want a complete program just to check for redelegations.</source>
+        <target state="new">Til slutt ble denne open source-versjonen av Zonemaster bygget ved hjelp av modulkode som i utgangspunktet betyr at du kan bruke deler av den i systemene dine hvis du ønsker det. Det er ganske sjelden at du har et komplett program bare for å sjekke for eksempel omlegeringer.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="f3a7aab6d6b07e6db0c1ba7e4b88f53430d5ce81" datatype="html">
@@ -490,14 +490,14 @@
         <target state="translated">Hvis du syns at et testresultat er feil så oppfordrer vi til å sende en e-post til <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:zonemaster-users@lists.iis.se&quot;&gt;"/>zonemaster-users@lists.iis.se<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (moderert e-postliste) med en lenke til testresultatet og forklar hvorfor du synes testen er feil.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="076e3c1beadaa4e6ba7989124471ab3d14bbc523" datatype="html">
-        <source>What kind of queries does Zonemaster generate?</source>
-        <target state="translated">Hvilke typer spørringer genererer Zonemaster?</target>
+      <trans-unit id="43b794c269088e266109a7e6325a2735fa84dea5" datatype="html">
+        <source>What kind of DNS queries does Zonemaster generate?</source>
+        <target state="new">Hvilke typer spørringer genererer Zonemaster?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="56c265f73e958064c7bcfee6e566516e03066c1a" datatype="html">
-        <source>Zonemaster send multiple DNS queries to the name servers hosting the domain name being tested and also to the name servers hosting the parent zone of that domain name.</source>
-        <target state="needs-l10n">Zonemaster vil generere forskjellige typer spørringer avhengig av hvordan DNS-serverne svarer.</target>
+      <trans-unit id="b8a8b9d2be7823698c2748be55f00c74bc24aebc" datatype="html">
+        <source>Zonemaster sends multiple DNS queries to the name servers hosting the domain name being tested and also to the name servers hosting the parent zone of that domain name.</source>
+        <target state="new">Zonemaster vil generere forskjellige typer spørringer avhengig av hvordan DNS-serverne svarer.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="441b723a458aa167da55ee24002ef0a38ac81a96" datatype="html">
@@ -515,9 +515,9 @@
         <target state="translated">Hvorfor kan jeg ikke teste mitt domene?</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="67269fee7f44c79618ab1c709d8dd53949545984" datatype="html">
-        <source>There are several possibilities:</source>
-        <target state="translated">Det er flere muligheter:</target>
+      <trans-unit id="0bdf75b30593d6ecbd74e34628d90e8530ec8e05" datatype="html">
+        <source>There are several possibilities.</source>
+        <target state="new">Det er flere muligheter:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="5ade768ec4a2e175bdcc18687d04ef22efa461da" datatype="html">
@@ -530,14 +530,14 @@
         <target state="translated">Ditt domene er ikke tilgjengelig fra internett.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="2c3a34d5c350d025523503260d7b7fd2be5bd297" datatype="html">
-        <source>Zonemaster can only test what is called a DNS zone (e.g. &apos;zonemaster.net&apos;) and not host names (e.g. &apos;www.zonemaster.net&apos;)</source>
-        <target state="translated">Zonemaster kan bare sjekke domener eller DNS-soner, som zonemaster.net, og ikke vertsnavn i et domene (sone), som www.zonemaster.net.</target>
+      <trans-unit id="af5d964bcd860fb4c49b4df68b7cbe3aa7d3b8a4" datatype="html">
+        <source>Zonemaster can only test what is called a DNS zone, for example &apos;zonemaster.net&apos;, and not host names, like &apos;www.zonemaster.net&apos;.</source>
+        <target state="new">Zonemaster kan bare sjekke domener eller DNS-soner, som zonemaster.net, og ikke vertsnavn i et domene (sone), som www.zonemaster.net.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="eb42d0a7485a530b74a81467195b779cdb447607" datatype="html">
-        <source>There is a 10 minutes protection between consecutive tests for a given domain name (with same test parameters). Running a test within that window will instead show the last available test for that domain name (and parameters).</source>
-        <target state="translated">Det er en periode på 10 minutter mellom hver gang man kan sjekke et domene med samme testparametere. His du prøver å teste det igjen innen 10 minutter vil det forrige resultatet vises i stedet.</target>
+      <trans-unit id="d31b5b7a11a5d9b2ef21b1b92f3b4a23550a5e24" datatype="html">
+        <source>There is a 10 minutes protection between consecutive tests for a given domain name, with same test parameters. Running a test within that window will instead show the last available test for that domain name, and parameters.</source>
+        <target state="new">Det er en periode på 10 minutter mellom hver gang man kan sjekke et domene med samme testparametere. His du prøver å teste det igjen innen 10 minutter vil det forrige resultatet vises i stedet.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="3fa205532eeda5bef22a1c0268e823b691682f2e" datatype="html">
@@ -555,19 +555,14 @@
         <target state="translated">Hva er et udelegert test?</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="e9e0008a5b47b371cc2f592e2b07f7f436f69579" datatype="html">
-        <source>An undelegated domain test is a test performed on a domain name that may, or may not, be fully published in the DNS. This can be quite useful if one is going to migrate one&apos;s domain from one registrar to another, e.g., migrate zone &apos;example.com&apos; from the name server &apos;ns.example.com&apos; to the name server &apos;ns.example.org&apos;. In this scenario one could perform an undelegated domain test providing the zone (&apos;example.com&apos;) and the name server you are migrating to (&apos;ns.example.org&apos;) before you migrate your domain. When the results of the test doesn&apos;t show any errors or warnings one can be fairly certain that the domain&apos;s new location is working well. However there might still be other problems in the zone data itself that this test is unaware of.</source>
-        <target state="needs-l10n">Du kan sjekke domener og navnetjenere som ikke er publisert i DNS, eller endringer av navnetjenere for et domene før endringen er publisert. Hvis testen er feilfri, kan du regne med at navnetjeneren vil svare på spørringer om domenet. Det kan imidlertid fortsatt være feil i soneinformasjonen som denne testen ikke kjenner til.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
       <trans-unit id="714b9a1e26a0fb83903c47c5861168eb802f14c8" datatype="html">
         <source>Does Zonemaster support IPv6?</source>
         <target state="translated">Håndterer Zonemaster IPv6?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="e202abce3d27b876ce27b42e2c65c4109d902e00" datatype="html">
-        <source>Yes. By default Zonemaster will query name servers both over IPv4 and IPv6, unless explicitly configured otherwise. Such configuration is accessible through the &quot;Options&quot; button.</source>
-        <target state="translated">Ja, alle tester kjøres på både IPv4 og IPv6. Man kan endre på dette ved å slå på &quot;Avansert sjekk&quot;.</target>
+      <trans-unit id="2350f8b4d24d63516eb8f8a6d71e67c72e323c15" datatype="html">
+        <source>Yes. By default Zonemaster will query name servers both over IPv4 and IPv6, unless explicitly configured otherwise. Such configuration is accessible through the &quot;Show options&quot; button.</source>
+        <target state="new">Ja, alle tester kjøres på både IPv4 og IPv6. Man kan endre på dette ved å slå på &quot;Avansert sjekk&quot;.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="0a5f5612b4d2dfb3a9bf032f9815e6228d0721a6" datatype="html">
@@ -585,9 +580,9 @@
         <target state="translated">Kan jeg teste DS-poster innen de er publisert?</target>
         <note priority="1" from="description">faq question</note>
       </trans-unit>
-      <trans-unit id="2e3dcb30f608294a8ca15718a32604ced7555f7a" datatype="html">
-        <source>Yes. Use the &quot;Options&quot; button and there add the Delegation Signer (DS) records to be tested. Zonemaster will then use those in the same way as if they were already added in the parent zone.</source>
-        <target state="translated">Ja, bruk valget &quot;Avansert sjekk&quot; for å kunne legge inn DS-poster du vil sjekke. Zonemaster bruker da de i steden for å hendte dem fra foreldresonen.</target>
+      <trans-unit id="82472afd59b9bd004901d8692b87752d48f62792" datatype="html">
+        <source>Yes. Use the &quot;Show options&quot; button and there add the Delegation Signer (DS) records to be tested. Zonemaster will then use those in the same way as if they were already added in the parent zone.</source>
+        <target state="new">Ja, bruk valget &quot;Avansert sjekk&quot; for å kunne legge inn DS-poster du vil sjekke. Zonemaster bruker da de i steden for å hendte dem fra foreldresonen.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="794667cd8ae08bd15b1d9943e03f8b2886ee6f65" datatype="html">
@@ -605,14 +600,14 @@
         <target state="translated">Eksempler:</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="93c29dbaff15d2569875f4e67925d39859eeb465" datatype="html">
-        <source>For IPv4 prefix &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa</source>
-        <target state="needs-l10n">reversoppslag for et IPv4-nett: Nettadressen er 194.98.30.0 og gir reversoppslagssonen 30.98.194.in-addr.arpa.</target>
+      <trans-unit id="f391e31fd1b3fb7063c9048af39cb6a95aa0a193" datatype="html">
+        <source>for IPv4 prefix &apos;198.51.100.0/24&apos;: 100.51.198.in-addr.arpa;</source>
+        <target state="new">reversoppslag for et IPv4-nett: Nettadressen er 194.98.30.0 og gir reversoppslagssonen 30.98.194.in-addr.arpa.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
-      <trans-unit id="699eaa999ec82b70f68bf14932cc97ad893a0e0b" datatype="html">
-        <source>For IPv6 prefix &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa</source>
-        <target state="needs-l10n">reversoppslag for et IPv6-nett: Nettadressen er 2001:660:3003::0 og gir reversoppslagssonen 3.0.0.3.0.6.6.0.1.0.0.2.ip6.arpa.</target>
+      <trans-unit id="c11b2629ee75f3f6ab277dd82b742a4b28c86a39" datatype="html">
+        <source>for IPv6 prefix &apos;2001:db8::/32&apos;: 8.b.d.0.1.0.0.2.ip6.arpa.</source>
+        <target state="new">reversoppslag for et IPv6-nett: Nettadressen er 2001:660:3003::0 og gir reversoppslagssonen 3.0.0.3.0.6.6.0.1.0.0.2.ip6.arpa.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="56a21bdcd76a6ac5dd60c17f5170b999b63e0ac0" datatype="html">
@@ -700,9 +695,9 @@
         <target state="new">Expand all modules</target>
         <note priority="1" from="description">result filter messages</note>
       </trans-unit>
-      <trans-unit id="99a0620d495f0d1ab864174f77a560140c5e214a" datatype="html">
-        <source>The descriptions of message levels such as <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>notice<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>warning<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> and <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> are found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Severity Level Definitions<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <target state="translated">Beskrivelse av de ulike nivåene på feilmeldinger, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>notice<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>warning<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, og <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, er beskrevet i <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Definisjoner av alvorlighetsgrad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
+      <trans-unit id="1653de50d322462bc8c27d7e1735fee3836e8475" datatype="html">
+        <source>The descriptions of message levels such as <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>NOTICE<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>WARNING<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> and <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>ERROR<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> are found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Severity Level Definitions<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target state="new">Beskrivelse av de ulike nivåene på feilmeldinger, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>notice<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>warning<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, og <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>error<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>, er beskrevet i <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md&quot;&gt;"/>Definisjoner av alvorlighetsgrad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
         <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="6d41e759de3c0117413b5a6e5b5cd3f44ecb4676" datatype="html">
@@ -712,80 +707,6 @@
       <trans-unit id="851258c348e2a703d4a845053c198287c11d5601" datatype="html">
         <source>Created on</source>
         <note priority="1" from="description">result test metadata</note>
-      </trans-unit>
-      <trans-unit id="c51835a3345882fb12374bddfd2e4b73e4f69db8" datatype="html">
-        <source>Zonemaster is a program designed to help people check, measure and hopefully also understand how the DNS (Domain Name System) works.</source>
-        <target state="translated">Zonemaster er et verktøy for å overvåke, måle og forstå hvordan domenenavnsystemet (DNS) virker.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="11aba2484b1af47b7dcd308237d231d0dd666d65" datatype="html">
-        <source>It consists of several components:</source>
-        <target state="translated">Zonemaster består av flere deler:</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="cd1f6944c474bd4875b37226edbe8ed0b802ef1a" datatype="html">
-        <source>Engine - a test framework that supports all functionality to perform DNS tests.</source>
-        <target state="translated">Motoren (kode som utfører testene).</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="8f95b69eb8b7f2620f2bf39028a754efbb02e17c" datatype="html">
-        <source>CLI - a command-line interface to the Engine.</source>
-        <target state="translated">CLI - et kommandolinje-grensesnitt mot motoren.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="fdfa7928b51beb9b7143d33143bf10e6330e0f84" datatype="html">
-        <source>Bakend - a server that allows you to run Zonemaster tests and save results using a JSON-RPC API and a database.</source>
-        <target state="translated">Backend - en tjener som kjører Zonemaster tester og lagrer resultater i en database.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="f607354c1d0aba750b042d6f9c715efb699b5b7e" datatype="html">
-        <source>GUI - a web interface to the Backend.</source>
-        <target state="translated">GUI - et webgrensesnitt mot Backend.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="57c82df8ab9888592cfd3419caf75ec72c794db6" datatype="html">
-        <source>When a domain name (such as &apos;zonemaster.net&apos;) is submitted to Zonemaster (using CLI or GUI), it will verify the domain name’s general health with a series of tests. The tests conducted by Zonemaster can be found in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>the Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
-        <target state="needs-l10n">Når et domene, også kalt en sone, blir testet, vil verktøyet ta en helsesjekk på domenet ved å gå gjennom DNS fra rota (.) til toppnivået, for eksempel .no, og til slutt DNS-serverne som inneholder informasjon om det spesifikke domenet, for eksempel eksempel.no. Zonemaster utfører også flere andre tester. Disse er dokumentert her, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definierte tester<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. Zonemaster kan teste både publiserte og upubliserte (ikke delegerte) domener.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="1072f67587614ba02bf775b31fcf47604c0a74d9" datatype="html">
-        <source>Users who are knowledgable about the DNS protocol.</source>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="bcc9e8cca9979fe26d8cc69c1b7dda20d67fb6ec" datatype="html">
-        <source>Secondly, all tests that Zonemaster runs are defined in Test Case specifications that can be found in the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
-        <target state="translated">Alle tester som Zonemaster kjører er definert i test-spesifikasjoner som er koblet til <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Kravdokument for test<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="93e3b326e8c6a335517ce06fd8e4fb60b32022d6" datatype="html">
-        <source>Thirdly, Zonemaster can be used to test undelegated domain names. See <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#what-is-an-undelegated-domain-test&quot;&gt;"/>Question 12<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <note priority="1" from="description">faq answer</note>
-        <target state="translated">Zonemaster kan brukes til å teste udelegerte domener. Mer om udelegert domener i <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#what-is-an-undelegated-domain-test&quot;&gt;"/>Spørsmål 12<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
-      </trans-unit>
-      <trans-unit id="d935513e236ca268ce40c309a7e3dc8ffdb4644b" datatype="html">
-        <source>Fourthly, Zonemaster can be used to test DS records before their publication in the parent zone (which is required to enable DNSSEC for a signed zone). See <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>Question 13<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <note priority="1" from="description">faq answer</note>
-        <target state="translated">Zonemaster kan brukes til å teste DS-poster innen de er publisert i foreldresonen. Dette trengs da man skal slå på DNSSEC for en signert sone. Se <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>Spørsmål 13<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
-      </trans-unit>
-      <trans-unit id="d64e48938dc174ff3a27321a096a8aed44cb55cf" datatype="html">
-        <source>The judgement of Zonemaster is primarily based on the DNS standards as defined in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;RFC Wikipedia link&quot; href=&quot;https://en.wikipedia.org/wiki/Request_for_Comments&quot;&gt;"/>RFCs<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. It also bases its judgement on DNS best practices, which can be more loosely defined. All Zonemaster tests are defined in <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Test Case Specifications<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> in which the references to the standard documents for that test case are found.</source>
-        <target state="translated">Det er viktig å understreke at ingen kan gi en endelig uttalelse om helsen til et domene. Zonemaster er ikke alltid fullstendig korrekt, og resultatene kan gi rom for tolkning. De som står bak testen understreker at de har gjort sitt aller beste for å utvikle en best mulig policy for vurdering av ulike feil før de blir presentert for deg som bruker verktøyet. Denne policy er basert på DNS-standarder som er definiert i ulike <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;RFC Wikipedia link&quot; href=&quot;https://en.wikipedia.org/wiki/Request_for_Comments&quot;&gt;"/>RFCs<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. Alle tester er definiert i <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definierte tester<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. Der er også alle referanser til forskjelling RFCer dokumentert.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="b37b77d5a9ec277db643fecb7e0d9e6ced910cfd" datatype="html">
-        <source>The GUI interface of Zonemaster does not show any queries sent, only the CLI interface can. If you want to see such queries, you will have to locally install a minimally working Zonemaster instance with both the Engine and CLI components (a Docker image is also available). Queries sent can be shown using the &apos;DEBUG&apos; level option. Fair warning, the output from the CLI can be quite heavy. For more information see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md&quot;&gt;"/>Using The CLI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <target state="translated">For å få en full visning av hvilke spørsmål og resultater som genereres, kan du kjøre CLI-grensesnittet og velg full utdata. For å kunne kjøre CLI-grensesnittet må du laste ned pakke og installer både CLI- og Engine-komponenten. Det finnes også en Docker image. Resultatet fra CLI-verktøyet er ganske tungt teknisk så med mindre du er interessert i bit og byte, vil du kanskje hoppe over dette trinnet. For mer informasjon se <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md&quot;&gt;"/>Bruk av CLI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="3e875c84ab956c8df30ae1965dc0cde70364441f" datatype="html">
-        <source>Since <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://zonemaster.net/&quot;&gt;"/>Zonemaster.net<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is open to everyone it is possible for anyone to check your domain and its history of tests. However there is no way to tell who has run a specific test since nothing more than the test parameters and results are stored. Specifically, no cookies or information on the user&apos;s IP address is stored in the database. The user who initiated the test cannot be traced back from the information in the database.</source>
-        <target state="translated"><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://zonemaster.net/&quot;&gt;"/>Zonemaster.net<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> er tilgjengelig for alle, dermed er det også mulig for alle å teste ditt domene og også se testhistorikk for domenet. Det er imidlertid ingen som kan se hvem som har gjort en test. Det eneste som er logget, er tidspunktet da testen ble utført. Hverken IP-adresse eller informasjonskapsler (cookies) blir lagret.</target>
-        <note priority="1" from="description">faq answer</note>
-      </trans-unit>
-      <trans-unit id="35616e74e8222cbe39e0e9e1d4451538fe760238" datatype="html">
-        <source>It depends on which test failed for your domain name. Each test are accompanied with one or several messages describing the issues found. You can also get further insight about each test from the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Defined Test Cases<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> document.</source>
-        <target state="translated">Det beror på hvilket test som gikk galt for domenet. Hvert testsvar innholder informasjon om hva som gikk galt med testen. Mer informasjon om hva som testes finnes i dokumentet <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#list-of-defined-test-cases&quot;&gt;"/>Definierte tester<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
-        <note priority="1" from="description">faq answer</note>
       </trans-unit>
       <trans-unit id="67f7a9ad43bbcaca9531388e8a49fcc6edcaed74" datatype="html">
         <source>Show options</source>
@@ -818,6 +739,98 @@
       <trans-unit id="c8519a4a202001557a05f640963735dbf5f07b33" datatype="html">
         <source>Digest of DS record #<x id="INTERPOLATION" equiv-text="{{i + 1}}"/></source>
         <note priority="1" from="description">form label</note>
+      </trans-unit>
+      <trans-unit id="2704926571b86d6e027c0ee69e9cf92df0cf9096" datatype="html">
+        <source>Zonemaster is a software package that validates the quality of a DNS delegation.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="1b3fa683ecfec35c6e3ac7fbfd50b7c689199a54" datatype="html">
+        <source>The ambition of the Zonemaster project is to develop and maintain an open source DNS validation tool, offering improved performance over existing tools and providing extensive documentation which could be re-used by similar projects in the future.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="51e39416d99fddd056c99788c01f9bc7b66f2037" datatype="html">
+        <source>Zonemaster consists of several modules or components:</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="e4f6c60a296bfd008d340c5dfff98bba363d3e82" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster-engine&quot;&gt;"/>Engine<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, a test framework that supports all functionality to perform DNS tests;</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="d26c43d02a42969864698f92af212eaf479d68e6" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster-cli&quot;&gt;"/>CLI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, a command-line interface to the Engine;</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="b9c39a4ac7f467c9db860a66a5ce8b1db9a1c820" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster-backend&quot;&gt;"/>Bakend<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, a server that allows you to run Zonemaster tests and save results using a JSON-RPC API and a database;</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="333892b5f3094578ceccffb29e7498c1c5fdf3b5" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster-engine&quot;&gt;"/>GUI<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, a web interface to the Backend.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="7aec1bc450ef7a1d3fbec65dc277ea4564f25c9e" datatype="html">
+        <source>The components will help different types of users to check domain servers for configuration errors and generate a report that will assist in fixing the errors.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="34d009ab9be7fd622ac9e49201cf5c6bdf747234" datatype="html">
+        <source>DNS administrator, experts and beginners alike, who want to check their DNS configuration;</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="f54e9dd707ef19b613b8e24eb27ff8c665a39e5d" datatype="html">
+        <source>All tests that Zonemaster runs are defined in the Test Case Specification documents that can be found in the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#zonemaster-test-case-specifications&quot;&gt;"/>Test Case Specification documents<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="92585a3d52e50d27907f2141840ef9d5800403f3" datatype="html">
+        <source>Zonemaster can be used to test <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;./faq#what-is-an-undelegated-domain-test&quot;&gt;"/>undelegated domain names<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="715189970a83f785ee5d931b3a2b33c6b60bc33f" datatype="html">
+        <source>Zonemaster can be used to test <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;./faq#can-i-test-the-ds-records-before-they-are-published&quot;&gt;"/>DS records before their publication<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> in the parent zone.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="e9d270f1198af607f593dfce5fa7a2e88a622f28" datatype="html">
+        <source>The judgement of Zonemaster is primarily based on the DNS standards as defined in <x id="START_LINK" ctype="x-a" equiv-text="&lt;a i18n-href=&quot;RFC Wikipedia link&quot; href=&quot;https://en.wikipedia.org/wiki/Request_for_Comments&quot;&gt;"/>RFCs<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. It also bases its judgement on DNS best practices, which can be more loosely defined.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="d42eedec9f66855cb398b2adc1f100ac8367a9cc" datatype="html">
+        <source>All Zonemaster tests are defined in the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#zonemaster-test-case-specifications&quot;&gt;"/>Test Case Specification documents<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> in which the references to the standard documents for each test case are found.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="b5d49764acaeaa151a5ac5febf896ee2b3057de0" datatype="html">
+        <source>The web interface of Zonemaster does not show the queries that were sent, only the CLI interface can. If you want to see such queries, you will have to locally install a minimally working Zonemaster instance with both the Engine and CLI components. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/installation/zonemaster-cli.md&quot;&gt;"/>CLI installation document<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for more information, or if you prefer a <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md#Invoking-the-command-line-tool-using-Docker&quot;&gt;"/>Docker image<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is also available.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="af1bfafbbbdcd9b1592d3d49c002a03ef057ee8f" datatype="html">
+        <source>Queries sent can be shown using the &apos;DEBUG&apos; level option. Fair warning, the output from the CLI can be quite heavy. For more information see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/blob/master/docs/public/using/cli.md&quot;&gt;"/>CLI usage documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="9f4317f4bde59f85c3e772bc3b42dba428e95ec7" datatype="html">
+        <source>Nothing besides the test domain, other test parameters and the result is stored in the database. Specifically we do not store any information that could link a test to the user who initiated it.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="6be3dc81fccabd1e5fa54d429e0e4badaf23db6a" datatype="html">
+        <source>However, since <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://zonemaster.net&quot;&gt;"/>zonemaster.net<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, like other public instances, is open to everyone, it is possible for anyone to test your domain and view its history of tests.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="246dc6711fe797f1957f4437cca0f6bc11cbee7f" datatype="html">
+        <source>It depends on which test failed for your domain name. Each test is accompanied with one or several messages describing the issues found.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="78746b70d4f4c7a88a5f6782efe53a3bc7cb4760" datatype="html">
+        <source>You can also get further insight about each test from the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://github.com/zonemaster/zonemaster/tree/master/docs/public/specifications/tests#zonemaster-test-case-specifications&quot;&gt;"/>Test Case Specification documents<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="3c349e204fd8fb384a917155fe745b99b649405f" datatype="html">
+        <source>An undelegated domain test is a test performed on a domain name that may, or may not, be fully published in the DNS.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="35389c3f661c8fdd9a78d46ea60aa8ed521432fa" datatype="html">
+        <source>This can be quite useful if one is going to migrate one&apos;s domain from one registrar to another, for example, migrate zone &apos;example.com&apos; from the name server &apos;ns.example.com&apos; to the name server &apos;ns.example.org&apos;. In this scenario one could perform an undelegated domain test providing the zone (&apos;example.com&apos;) and the name server you are migrating to (&apos;ns.example.org&apos;) before you migrate your domain.</source>
+        <note priority="1" from="description">faq answer</note>
+      </trans-unit>
+      <trans-unit id="9ba22e50f767264efe18722dc728c9ee402181dc" datatype="html">
+        <source>When the results of the test doesn&apos;t show any errors or warnings one can be fairly certain that the domain&apos;s new location is working well. However there might still be other problems in the zone data itself that this test is unaware of.</source>
+        <note priority="1" from="description">faq answer</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
This PR restores #451 that was closed by mistake.

## Purpose

Fix the missing translation of the FAQ.

## Context

The translation system of the FAQ has changed. This import old translation into the new system.

## Changes

Norwegian translation.

## How to test this PR

A quick check of the translated string would be welcome to verify that I haven't done any mistake while copy/pasting.

**Note:** It felt to me that some text differs from the original in content for some FAQ items, maybe it should be reviewed and updated accordingly to be more inline with the other languages.