### PR TITLE
Fix typos in nginx example configuration

### DIFF
--- a/zonemaster-nginx.conf-example
+++ b/zonemaster-nginx.conf-example
@@ -1,7 +1,7 @@
 server {
     listen 80;
 
-    root /var/www/html/zonemaster-web-gui/dist
+    root /var/www/html/zonemaster-web-gui/dist;
     index index.html;
 
     location /api {
@@ -19,7 +19,7 @@ server {
     }
 
     # Rewrite /{lang}/result/{id} to /{lang}/result/id/index.html
-    location ~ ^/[^/]+/result/[^/]+/?$ {
+    location ~ ^/([^/]+)/result/[^/]+/?$ {
         set $lang $1;
         try_files /$lang/result/id/index.html =404;
     }


### PR DESCRIPTION
## Purpose

This PR fixes errors in the example configuration file for nginx which prevent correct operation of the GUI when installed on that server.

## Context

Release testing for 2025.2.

## Changes

* Fix two errors in `zonemaster-nginx.conf-example`.

## How to test this PR

There are no installation instructions in zonemaster/zonemaster yet for nginx. The instructions below should work for Ubuntu 22.04.

Install nginx:
```
sudo apt install nginx
```

Install the appropriate configuration files for nginx (assuming the current working directory is the root of the Git repository):
```
sudo install -m 0644 -v zonemaster-nginx.conf-example /etc/nginx/sites-available/zonemaster
sudo rm /etc/nginx/sites-enabled/default
sudo ln -nsf ../sites-available/zonemaster /etc/nginx/sites-enabled/
```

Enable and start nginx:
```
sudo systemctl enable nginx
sudo systemctl start nginx
```

Ensure that nginx is running:
```
sudo systemctl status nginx
```

Browse to the URL from which the GUI is being served. Run a test for any domain. After completion of the test, the results page should appear.
