### PR TITLE
All languages should have a prefix

### DIFF
--- a/src/themes/default/LanguageSwitcher.astro
+++ b/src/themes/default/LanguageSwitcher.astro
@@ -24,7 +24,6 @@ const languages = {
     <select
         class="zm-language-switcher__select"
         id="languageSwitcher"
-        data-source-language={config.defaultLanguage}
         data-current-language={currentLanguage}
     >
         {
@@ -42,9 +41,7 @@ const languages = {
 </div>
 <script>
     const languageSwitcher = document.getElementById('languageSwitcher');
-    const sourceLanguage = languageSwitcher?.getAttribute(
-        'data-source-language',
-    );
+
     function switchToLanguage(e: Event) {
         const currentLanguage = languageSwitcher?.getAttribute(
             'data-current-language',


### PR DESCRIPTION
## Purpose

Fixes an issue with the language switcher. Before this fix, the language switcher caused a 404 when switching back to the default language when visiting a sub page.

## Context

When we made the switch to include language prefix for the default language we forgot to also update the language switcher.

## Changes

The language switcher includes a prefix for all languages now, even the default language.

## How to test this PR

1. Visit /en/faq
2. Switch to Swedish and you'll land on /sv/faq
3. Switch back to English and you should land on /en/faq again (compared to /faq before this fix)
