### PR TITLE
Add GUI artifact build to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,12 @@ jobs:
 
       - name: Get short SHA
         id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: |
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+                echo "SHORT_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_ENV
+            else
+                echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+            fi
 
       - name: Get Zonemaster-GUI version
         id: version
@@ -66,5 +71,5 @@ jobs:
       - name: upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: zonemaster_web_gui_v${{ steps.version.outputs.version }}-${{ steps.short_sha.outputs.short_sha }}
+          name: zonemaster_web_gui_v${{ steps.version.outputs.version }}-${{ env.SHORT_SHA }}
           path: zonemaster_web_gui_v${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
           node-version: 24.x
           cache: npm
 
+      - name: update
+        run: sudo apt update -y
+
       - name: apt install
         run: sudo apt-get install -y git jq
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,38 @@ jobs:
 
       - name: Run e2e tests
         run: npm run e2e
+
+  build-artifact:
+    needs: tests_e2e
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: apt install
+        run: sudo apt-get install -y git jq
+
+      - name: build
+        run: |
+          npm install
+          npm run release
+
+      - name: Get short SHA
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Get Zonemaster-GUI version
+        id: version
+        run: |
+          VERSION=`jq -r '.version | sub("^v"; "")' package.json`
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zonemaster_web_gui_v${{ steps.version.outputs.version }}-${{ steps.short_sha.outputs.short_sha }}
+          path: zonemaster_web_gui_v${{ steps.version.outputs.version }}.zip

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To download it:
 1. Go to the [Actions tab](https://github.com/zonemaster/zonemaster-gui/actions) of the repository.
 2. Select a workflow run (e.g. for a specific PR or branch).
 3. Scroll to the bottom of the run summary to the **Artifacts** section.
-4. Download the artifact named `Zonemaster-LDNS-<version>-<short_sha>` `zonemaster_web_gui_<version>-<short_sha>`.
+4. Download the artifact named `zonemaster_web_gui_<version>-<short_sha>`.
 The artifact name includes the module version and the first 7 characters of the commit SHA.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Refer to the [docs](/docs) directory for detailed information on:
 
 For contribution guidelines, see [CONTRIBUTE.md](CONTRIBUTE.md).
 
+## CI artifact
+
+A zip (`zonemaster_web_gui_<version>.zip`) is built and uploaded as a GitHub Actions artifact on every push and pull request. This artifact can be useful for release testing and PR review.
+To download it:
+1. Go to the [Actions tab](https://github.com/zonemaster/zonemaster-gui/actions) of the repository.
+2. Select a workflow run (e.g. for a specific PR or branch).
+3. Scroll to the bottom of the run summary to the **Artifacts** section.
+4. Download the artifact named `Zonemaster-LDNS-<version>-<short_sha>` `zonemaster_web_gui_<version>-<short_sha>`.
+The artifact name includes the module version and the first 7 characters of the commit SHA.
+
 ## License
 
 This is free software under a 2-clause BSD license. The full text of the license can be found in the [LICENSE](LICENSE) file included in this repository.


### PR DESCRIPTION
## Purpose

This PR adds artifact creation to CI. This artifact can be useful for release testing and PR review.
The artifact is created only if all tests pass.

## Context

Follow-up to https://github.com/zonemaster/zonemaster-backend/issues/1229

## How to test this PR

You should be able to download the artifact from the action tab and install it by following the Zonemaster documentation.
https://doc.zonemaster.net/latest/installation/zonemaster-gui.html
