### PR TITLE
Handle empty testcase values in results

### DIFF
--- a/e2e/FR26.e2e-spec.ts
+++ b/e2e/FR26.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from './global-setup';
+
+test.describe('Zonemaster test FR26 - [Shows results with empty testcases]', () => {
+    test('shows a result with an empty testcase', async ({
+        page,
+    }) => {
+        await page.goto('/en/result/empty-testcase-response/');
+
+        await expect(page.locator('.zm-result')).toBeVisible({
+            timeout: 10000,
+        });
+        await expect(
+            page.getByRole('heading', {
+                name: 'Test result for empty-testcase.example',
+            }),
+        ).toBeVisible();
+
+        await page.getByRole('button', { name: 'Expand all modules' }).click();
+
+        await expect(page.locator('#zmModule-Backend-content')).toContainText(
+            'The backend returned a result without a testcase.',
+        );
+    });
+});

--- a/e2e/interceptors/mock.interceptor.ts
+++ b/e2e/interceptors/mock.interceptor.ts
@@ -40,7 +40,6 @@ const urls: MockEndpoint[] = [
     },
 
     // FR18 - Should display progress bar
-    // FR26 - Should display progress bar
     {
         url: 'http://localhost:4321/api',
         body: {'jsonrpc': '2.0', 'id': 1572254767685, 'method': 'start_domain_test', 'params':
@@ -113,7 +112,6 @@ const urls: MockEndpoint[] = [
     // FR18 - Should display progress bar
     // FR19 - Should display progress bar when we add a NS name
     // FR20 - should display progress bar when we add a DS entry and launch a test
-    // FR26 - Should display progress bar
     {
         url: 'http://localhost:4321/api',
         body: {'jsonrpc': '2.0', 'id': 1572254972236, 'method': 'test_progress', 'params': {'test_id': '2005cf23e9fb24b6'}},
@@ -880,6 +878,39 @@ const urls: MockEndpoint[] = [
                         "testcase": "ZONE10"
                     }
                 ]
+            }
+        }
+    },
+    // Result returned without a testcase.
+    {
+        url: 'http://localhost:4321/api',
+        body: {'jsonrpc': '2.0', 'id': 1, 'method': 'get_test_results', 'params': {'id': 'empty-testcase-response', 'language': 'en'}},
+        method: 'POST',
+        json: {'jsonrpc': '2.0', 'id': 1, 'result': {
+                'results': [
+                    {
+                        'level': 'CRITICAL',
+                        'testcase': '',
+                        'module': 'Backend',
+                        'message': 'The backend returned a result without a testcase.\n'
+                    }
+                ],
+                'params': {
+                    'profile': 'default',
+                    'ipv6': true,
+                    'ds_info': [],
+                    'language': 'en',
+                    'priority': 10,
+                    'queue': 0,
+                    'client_id': 'Zonemaster-GUI',
+                    'ipv4': true,
+                    'domain': 'empty-testcase.example',
+                    'nameservers': [],
+                    'client_version': 'v5.0.1'
+                },
+                'testcase_descriptions': {'': ''},
+                'created_at': '2026-04-02T11:15:15Z',
+                'hash_id': 'empty-testcase-response'
             }
         }
     },

--- a/src/lib/groupResult.ts
+++ b/src/lib/groupResult.ts
@@ -25,7 +25,7 @@ export function groupResult(results: ResultDataResult[]) {
 
     for (const entry of results) {
         const currentModule = entry.module;
-        const currentTestcase = entry.testcase;
+        const currentTestcase = entry.testcase || 'Unspecified';
         const currentLevel = entry.level;
         const numLevel = severityLevels[entry.level];
 

--- a/src/lib/niceName.ts
+++ b/src/lib/niceName.ts
@@ -1,5 +1,9 @@
 // Lowercase and capitalize
 export default function niceName(name: string): string {
+    if (!name) {
+        return '';
+    }
+
     const [first, ...rest] = name.toLowerCase();
 
     return first.toUpperCase() + rest.join('');


### PR DESCRIPTION
## Purpose

This PR fixes rendering of result entries where the backend returns an empty `testcase` value.

## Context

Fixes #541 

The reported timeout result is one example of this response shape: the backend can return a valid result entry with `testcase: ""`. The GUI previously failed to display that entry correctly.

## Changes

- Treat empty `testcase` values as `Unspecified` when grouping results.
- Make `niceName()` tolerate empty input safely.
- Add `FR26` e2e coverage for a result response containing an empty testcase.
- Add a mocked `empty-testcase-response` result fixture for the e2e test.

## How to test this PR

Run:

```sh
npm run e2e -- e2e/FR26.e2e-spec.ts
```

Or manually by testing a domain that results in a timeout.